### PR TITLE
(stacked bar/column) set ticks to 0/25/50/75/100 if all sums are 100

### DIFF
--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -42,12 +42,12 @@ module.exports = function getMapping(config = {}) {
         // set the barWidth depending on the number of bars we will get
         const numberOfBars = itemData.length - 1;
         const barWidthSignal = spec.signals.find(signal => {
-          return signal.name === 'barWidth'
+          return signal.name === "barWidth";
         });
         if (numberOfBars > 10) {
-          barWidthSignal.value = 16
+          barWidthSignal.value = 16;
         } else {
-          barWidthSignal.value = 24
+          barWidthSignal.value = 24;
         }
 
         // check if we need to shorten the number labels
@@ -127,6 +127,34 @@ module.exports = function getMapping(config = {}) {
             }
           });
         }
+      }
+    },
+    {
+      path: "data",
+      mapToSpec: function(itemData, spec, item, id) {
+        // check if all rows sum up to 100
+        const stackedSums = itemData
+          .slice(1)
+          .map(row => {
+            return row.slice(1).reduce((sum, cell) => {
+              return sum + cell;
+            }, 0);
+          })
+          .reduce((uniqueSums, sum) => {
+            if (!uniqueSums.includes(sum)) {
+              uniqueSums.push(sum);
+            }
+            return uniqueSums;
+          }, []);
+
+        // if the sums are not unique or do not equal 100, do nothing
+        if (stackedSums.length !== 1 || Math.floor(stackedSums[0]) !== 100) {
+          return;
+        }
+
+        // set the ticks to 0/25/50/75/100
+        objectPath.set(spec, "axes.0.tickCount", undefined);
+        objectPath.set(spec, "axes.0.values", [0, 25, 50, 75, 100]);
       }
     },
     {

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -46,6 +46,34 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
+      path: "data",
+      mapToSpec: function(itemData, spec, item, id) {
+        // check if all rows sum up to 100
+        const stackedSums = itemData
+          .slice(1)
+          .map(row => {
+            return row.slice(1).reduce((sum, cell) => {
+              return sum + cell;
+            }, 0);
+          })
+          .reduce((uniqueSums, sum) => {
+            if (!uniqueSums.includes(sum)) {
+              uniqueSums.push(sum);
+            }
+            return uniqueSums;
+          }, []);
+
+        // if the sums are not unique or do not equal 100, do nothing
+        if (stackedSums.length !== 1 || Math.floor(stackedSums[0]) !== 100) {
+          return;
+        }
+
+        // set the ticks to 0/25/50/75/100
+        objectPath.set(spec, "axes.1.tickCount", undefined);
+        objectPath.set(spec, "axes.1.values", [0, 25, 50, 75, 100]);
+      }
+    },
+    {
       path: "options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec, item) {
         if (hideAxisLabel === true) {

--- a/resources/fixtures/data/bar-stacked-100.json
+++ b/resources/fixtures/data/bar-stacked-100.json
@@ -1,0 +1,28 @@
+{
+  "title": "FIXTURE: StackedBar - 100",
+  "subtitle": "some subtitle here",
+  "data": [
+    [
+      "Abstimmung",
+      "Ja: 46.02%",
+      "Nein: 53.98%"
+    ],
+    [
+      "in %",
+      "46.02",
+      "53.98"
+    ]
+  ],
+  "options": {
+    "chartType": "StackedBar",
+    "hideAxisLabel": false,
+    "barOptions": {
+      "isBarChart": false,
+      "forceBarsOnSmall": true
+    },
+    "dateSeriesOptions": {},
+    "lineChartOptions": {},
+    "colorOverwrite": [],
+    "highlightDataSeries": null
+  }
+}

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -10,6 +10,7 @@ const fixtureData = [
   require(`${fixtureDataDirectory}/bar-dates-years.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-negative.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-single-serie.json`),
+  require(`${fixtureDataDirectory}/bar-stacked-100.json`),
   require(`${fixtureDataDirectory}/bar-stacked-days-prognosis.json`),
   require(`${fixtureDataDirectory}/bar-stacked-qualitative-negative.json`),
   require(`${fixtureDataDirectory}/dotplot-empty-cells.json`),


### PR DESCRIPTION
In case stacked bars sum up to 100 it's most often a percentage that is shown. In this case we want to have a tick at 50%, especially when it's about vote results.

This PR sets fixed tick values in case all sums are 100 for stacked bars and columns.