### PR TITLE
Feat aspect ratio

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
         "DIVERGING_COLOR_SCHEMES": "[{ \"label\": \"one\", \"key\": 0, \"scheme_name\": \"diverging_one\" }, { \"label\": \"two\", \"key\": 1, \"scheme_name\": \"diverging_two\" }, { \"label\": \"three\", \"key\": 2, \"scheme_name\": \"diverging_three\" } ]",
         "FONTS": "[{\"url\": \"https://assets.static-nzz.ch/nzz-niobe/assets/fonts/GT-America-Standard-Regular.otf\",\"name\": \"nzz-sans-serif\",\"filename\": \"nzz-sans-serif.otf\"}]"
       },
-      "runtimeVersion": "10.6.0",
+      "runtimeVersion": "10.11.0",
       "program": "${workspaceRoot}/index.js"
     }
   ]

--- a/chartTypes/arrow/mapping.js
+++ b/chartTypes/arrow/mapping.js
@@ -137,13 +137,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.arrowOptions.minValue",
-      mapToSpec: function(minValue, spec, renderingInfoInput) {
+      mapToSpec: function(minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(
-          renderingInfoInput.item.data
-        );
+        const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -154,13 +152,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.arrowOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/arrow/mapping.js
+++ b/chartTypes/arrow/mapping.js
@@ -13,11 +13,11 @@ const textMetrics = require("vega").textMetrics;
 
 const configuredDivergingColorSchemes = require("../../helpers/colorSchemes.js").getConfiguredDivergingColorSchemes();
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
@@ -126,8 +126,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
@@ -136,12 +136,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.arrowOptions.minValue",
-      mapToSpec: function(minValue, spec, item) {
+      path: "item.options.arrowOptions.minValue",
+      mapToSpec: function(minValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(item.data);
+        const dataMinValue = dataHelpers.getMinValue(
+          renderingInfoInput.item.data
+        );
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -151,12 +153,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.arrowOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.arrowOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -166,8 +170,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.arrowOptions.colorScheme",
-      mapToSpec: function(colorScheme, spec, item) {
+      path: "item.options.arrowOptions.colorScheme",
+      mapToSpec: function(colorScheme, spec) {
         if (
           configuredDivergingColorSchemes &&
           configuredDivergingColorSchemes[colorScheme]
@@ -181,8 +185,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.first",
-      mapToSpec: function(showFirstAnimation, spec, item) {
+      path: "item.options.annotations.first",
+      mapToSpec: function(showFirstAnimation, spec) {
         if (!showFirstAnimation) {
           return;
         }
@@ -229,8 +233,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.last",
-      mapToSpec: function(showLastAnnotation, spec, item) {
+      path: "item.options.annotations.last",
+      mapToSpec: function(showLastAnnotation, spec) {
         if (!showLastAnnotation) {
           return;
         }
@@ -277,8 +281,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.diff",
-      mapToSpec: function(showDiffAnnotation, spec, item) {
+      path: "item.options.annotations.diff",
+      mapToSpec: function(showDiffAnnotation, spec) {
         if (!showDiffAnnotation) {
           return;
         }
@@ -325,5 +329,5 @@ module.exports = function getMapping(config = {}) {
         spec.marks[0].marks[0].marks.push(diffTextMarksSpec);
       }
     }
-  ].concat(commonMappings.getBarLabelColorMappings(config));
+  ].concat(commonMappings.getBarLabelColorMappings());
 };

--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -11,8 +11,8 @@ const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
 const textMetrics = require("vega").textMetrics;
 
-function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
-  const item = renderingInfoInput.item;
+function shouldHaveLabelsOnTopOfBar(mappingData) {
+  const item = mappingData.item;
   // this does not work for positive and negative values. so if we have both, we do not show the labels on top
   const minValue = dataHelpers.getMinValue(item.data);
   const maxValue = dataHelpers.getMaxValue(item.data);
@@ -20,13 +20,13 @@ function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
     return false;
   }
 
-  const longestLabel = getLongestDataLabel(renderingInfoInput, true);
+  const longestLabel = getLongestDataLabel(mappingData, true);
   const textItem = {
     text: longestLabel
   };
   const longestLabelWidth = textMetrics.width(textItem);
 
-  if (renderingInfoInput.width / 3 < longestLabelWidth) {
+  if (mappingData.width / 3 < longestLabelWidth) {
     return true;
   }
   return false;
@@ -36,8 +36,8 @@ module.exports = function getMapping() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(itemData, spec, mappingData) {
+        const item = mappingData.item;
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
@@ -83,7 +83,7 @@ module.exports = function getMapping() {
         );
         numberOfDataSeriesSignal.value = itemData[0].length - 1; // the first column is not a data column, so we subtract it
 
-        if (shouldHaveLabelsOnTopOfBar(renderingInfoInput)) {
+        if (shouldHaveLabelsOnTopOfBar(mappingData)) {
           spec.axes[1].labels = false;
 
           // flush the X axis labels if we have the labels on top of the bar
@@ -100,7 +100,7 @@ module.exports = function getMapping() {
           // if we have a date series, we need to format the label accordingly
           // otherwise we use the exact xValue as the label
           const labelText = {};
-          if (renderingInfoInput.dateFormat) {
+          if (mappingData.dateFormat) {
             const d3format =
               intervals[item.options.dateSeriesOptions.interval].d3format;
             labelText.signal = `timeFormat(datum.xValue, '${
@@ -171,13 +171,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -11,7 +11,8 @@ const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
 const textMetrics = require("vega").textMetrics;
 
-function shouldHaveLabelsOnTopOfBar(item, config) {
+function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
+  const item = renderingInfoInput.item;
   // this does not work for positive and negative values. so if we have both, we do not show the labels on top
   const minValue = dataHelpers.getMinValue(item.data);
   const maxValue = dataHelpers.getMaxValue(item.data);
@@ -19,23 +20,24 @@ function shouldHaveLabelsOnTopOfBar(item, config) {
     return false;
   }
 
-  const longestLabel = getLongestDataLabel(item, config, true);
+  const longestLabel = getLongestDataLabel(renderingInfoInput, true);
   const textItem = {
     text: longestLabel
   };
   const longestLabelWidth = textMetrics.width(textItem);
 
-  if (config.width / 3 < longestLabelWidth) {
+  if (renderingInfoInput.width / 3 < longestLabelWidth) {
     return true;
   }
   return false;
 }
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
@@ -81,7 +83,7 @@ module.exports = function getMapping(config = {}) {
         );
         numberOfDataSeriesSignal.value = itemData[0].length - 1; // the first column is not a data column, so we subtract it
 
-        if (shouldHaveLabelsOnTopOfBar(item, config)) {
+        if (shouldHaveLabelsOnTopOfBar(renderingInfoInput)) {
           spec.axes[1].labels = false;
 
           // flush the X axis labels if we have the labels on top of the bar
@@ -98,7 +100,7 @@ module.exports = function getMapping(config = {}) {
           // if we have a date series, we need to format the label accordingly
           // otherwise we use the exact xValue as the label
           const labelText = {};
-          if (config.dateFormat) {
+          if (renderingInfoInput.dateFormat) {
             const d3format =
               intervals[item.options.dateSeriesOptions.interval].d3format;
             labelText.signal = `timeFormat(datum.xValue, '${
@@ -130,8 +132,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item, id) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         // check if all rows sum up to 100
         const stackedSums = itemData
           .slice(1)
@@ -158,8 +160,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
@@ -168,12 +170,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.barOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -183,7 +187,7 @@ module.exports = function getMapping(config = {}) {
       }
     }
   ]
-    .concat(commonMappings.getBarDateSeriesHandlingMappings(config))
-    .concat(commonMappings.getBarPrognosisMappings(config))
-    .concat(commonMappings.getBarLabelColorMappings(config));
+    .concat(commonMappings.getBarDateSeriesHandlingMappings())
+    .concat(commonMappings.getBarPrognosisMappings())
+    .concat(commonMappings.getBarLabelColorMappings());
 };

--- a/chartTypes/bar/mapping.js
+++ b/chartTypes/bar/mapping.js
@@ -10,8 +10,8 @@ const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
 const textMetrics = require("vega").textMetrics;
 
-function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
-  const item = renderingInfoInput.item;
+function shouldHaveLabelsOnTopOfBar(mappingData) {
+  const item = mappingData.item;
   // this does not work for positive and negative values. so if we have both, we do not show the labels on top
   const minValue = dataHelpers.getMinValue(item.data);
   const maxValue = dataHelpers.getMaxValue(item.data);
@@ -19,13 +19,13 @@ function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
     return false;
   }
 
-  const longestLabel = getLongestDataLabel(renderingInfoInput, true);
+  const longestLabel = getLongestDataLabel(mappingData, true);
   const textItem = {
     text: longestLabel
   };
   const longestLabelWidth = textMetrics.width(textItem);
 
-  if (renderingInfoInput.width / 3 < longestLabelWidth) {
+  if (mappingData.width / 3 < longestLabelWidth) {
     return true;
   }
   return false;
@@ -35,8 +35,8 @@ module.exports = function getMapping() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(itemData, spec, mappingData) {
+        const item = mappingData.item;
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
@@ -82,7 +82,7 @@ module.exports = function getMapping() {
         );
         numberOfDataSeriesSignal.value = itemData[0].length - 1; // the first column is not a data column, so we subtract it
 
-        if (shouldHaveLabelsOnTopOfBar(renderingInfoInput)) {
+        if (shouldHaveLabelsOnTopOfBar(mappingData)) {
           spec.axes[1].labels = false;
 
           // flush the X axis labels if we have the labels on top of the bar
@@ -99,7 +99,7 @@ module.exports = function getMapping() {
           // if we have a date series, we need to format the label accordingly
           // otherwise we use the exact xValue as the label
           const labelText = {};
-          if (renderingInfoInput.dateFormat) {
+          if (mappingData.dateFormat) {
             const d3format =
               intervals[item.options.dateSeriesOptions.interval].d3format;
             labelText.signal = `timeFormat(datum.xValue, '${
@@ -142,13 +142,11 @@ module.exports = function getMapping() {
     },
     {
       path: "options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/bar/mapping.js
+++ b/chartTypes/bar/mapping.js
@@ -10,7 +10,8 @@ const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
 const textMetrics = require("vega").textMetrics;
 
-function shouldHaveLabelsOnTopOfBar(item, config) {
+function shouldHaveLabelsOnTopOfBar(renderingInfoInput) {
+  const item = renderingInfoInput.item;
   // this does not work for positive and negative values. so if we have both, we do not show the labels on top
   const minValue = dataHelpers.getMinValue(item.data);
   const maxValue = dataHelpers.getMaxValue(item.data);
@@ -18,35 +19,36 @@ function shouldHaveLabelsOnTopOfBar(item, config) {
     return false;
   }
 
-  const longestLabel = getLongestDataLabel(item, config, true);
+  const longestLabel = getLongestDataLabel(renderingInfoInput, true);
   const textItem = {
     text: longestLabel
   };
   const longestLabelWidth = textMetrics.width(textItem);
 
-  if (config.width / 3 < longestLabelWidth) {
+  if (renderingInfoInput.width / 3 < longestLabelWidth) {
     return true;
   }
   return false;
 }
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
         // set the barWidth depending on the number of bars we will get
         const numberOfBars = (itemData.length - 1) * itemData[0].length;
         const barWidthSignal = spec.signals.find(signal => {
-          return signal.name === 'barWidth'
+          return signal.name === "barWidth";
         });
         if (numberOfBars > 10) {
-          barWidthSignal.value = 16
+          barWidthSignal.value = 16;
         } else {
-          barWidthSignal.value = 24
+          barWidthSignal.value = 24;
         }
 
         // check if we need to shorten the number labels
@@ -80,7 +82,7 @@ module.exports = function getMapping(config = {}) {
         );
         numberOfDataSeriesSignal.value = itemData[0].length - 1; // the first column is not a data column, so we subtract it
 
-        if (shouldHaveLabelsOnTopOfBar(item, config)) {
+        if (shouldHaveLabelsOnTopOfBar(renderingInfoInput)) {
           spec.axes[1].labels = false;
 
           // flush the X axis labels if we have the labels on top of the bar
@@ -97,7 +99,7 @@ module.exports = function getMapping(config = {}) {
           // if we have a date series, we need to format the label accordingly
           // otherwise we use the exact xValue as the label
           const labelText = {};
-          if (config.dateFormat) {
+          if (renderingInfoInput.dateFormat) {
             const d3format =
               intervals[item.options.dateSeriesOptions.interval].d3format;
             labelText.signal = `timeFormat(datum.xValue, '${
@@ -129,8 +131,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
@@ -140,11 +142,13 @@ module.exports = function getMapping(config = {}) {
     },
     {
       path: "options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -154,7 +158,7 @@ module.exports = function getMapping(config = {}) {
       }
     }
   ]
-    .concat(commonMappings.getBarDateSeriesHandlingMappings(config))
-    .concat(commonMappings.getBarPrognosisMappings(config))
-    .concat(commonMappings.getBarLabelColorMappings(config));
+    .concat(commonMappings.getBarDateSeriesHandlingMappings())
+    .concat(commonMappings.getBarPrognosisMappings())
+    .concat(commonMappings.getBarLabelColorMappings());
 };

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -83,14 +83,14 @@ module.exports = function getMapping() {
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         } else {
           // Aspect ratio 7:3
           height = spec.width * (3 / 7);
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         }
       }
     },

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -74,6 +74,27 @@ module.exports = function getMapping() {
       }
     },
     {
+      path: "toolRuntimeConfig.displayOptions.size",
+      mapToSpec: function(size, spec) {
+        let height;
+        if (size === "prominent") {
+          // Aspect ratio 16:9
+          height = spec.width * (9 / 16);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        } else {
+          // Aspect ratio 7:3
+          height = spec.width * (3 / 7);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        }
+      }
+    },
+    {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -5,10 +5,10 @@ const dataHelpers = require("../../helpers/data.js");
 
 const commonMappings = require("../commonMappings.js");
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
+      path: "item.data",
       mapToSpec: function(itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
@@ -46,8 +46,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item, id) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         // check if all rows sum up to 100
         const stackedSums = itemData
           .slice(1)
@@ -74,8 +74,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
@@ -84,12 +84,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.barOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -99,7 +101,7 @@ module.exports = function getMapping(config = {}) {
       }
     }
   ]
-    .concat(commonMappings.getColumnDateSeriesHandlingMappings(config))
-    .concat(commonMappings.getColumnPrognosisMappings(config))
-    .concat(commonMappings.getColumnLabelColorMappings(config));
+    .concat(commonMappings.getColumnDateSeriesHandlingMappings())
+    .concat(commonMappings.getColumnPrognosisMappings())
+    .concat(commonMappings.getColumnLabelColorMappings());
 };

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -85,13 +85,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -74,27 +74,6 @@ module.exports = function getMapping() {
       }
     },
     {
-      path: "toolRuntimeConfig.displayOptions.size",
-      mapToSpec: function(size, spec) {
-        let height;
-        if (size === "prominent") {
-          // Aspect ratio 16:9
-          height = spec.width * (9 / 16);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        } else {
-          // Aspect ratio 7:3
-          height = spec.width * (3 / 7);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        }
-      }
-    },
-    {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
@@ -124,5 +103,6 @@ module.exports = function getMapping() {
   ]
     .concat(commonMappings.getColumnDateSeriesHandlingMappings())
     .concat(commonMappings.getColumnPrognosisMappings())
-    .concat(commonMappings.getColumnLabelColorMappings());
+    .concat(commonMappings.getColumnLabelColorMappings())
+    .concat(commonMappings.getHeightMappings());
 };

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -55,14 +55,14 @@ module.exports = function getMapping() {
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         } else {
           // Aspect ratio 7:3
           height = spec.width * (3 / 7);
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         }
       }
     },

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -46,6 +46,27 @@ module.exports = function getMapping() {
       }
     },
     {
+      path: "toolRuntimeConfig.displayOptions.size",
+      mapToSpec: function(size, spec) {
+        let height;
+        if (size === "prominent") {
+          // Aspect ratio 16:9
+          height = spec.width * (9 / 16);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        } else {
+          // Aspect ratio 7:3
+          height = spec.width * (3 / 7);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        }
+      }
+    },
+    {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -5,10 +5,10 @@ const dataHelpers = require("../../helpers/data.js");
 
 const commonMappings = require("../commonMappings.js");
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
+      path: "item.data",
       mapToSpec: function(itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
@@ -46,8 +46,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
@@ -56,12 +56,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.barOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -71,7 +73,7 @@ module.exports = function getMapping(config = {}) {
       }
     }
   ]
-    .concat(commonMappings.getColumnDateSeriesHandlingMappings(config))
-    .concat(commonMappings.getColumnPrognosisMappings(config))
-    .concat(commonMappings.getColumnLabelColorMappings(config));
+    .concat(commonMappings.getColumnDateSeriesHandlingMappings())
+    .concat(commonMappings.getColumnPrognosisMappings())
+    .concat(commonMappings.getColumnLabelColorMappings());
 };

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -46,27 +46,6 @@ module.exports = function getMapping() {
       }
     },
     {
-      path: "toolRuntimeConfig.displayOptions.size",
-      mapToSpec: function(size, spec) {
-        let height;
-        if (size === "prominent") {
-          // Aspect ratio 16:9
-          height = spec.width * (9 / 16);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        } else {
-          // Aspect ratio 7:3
-          height = spec.width * (3 / 7);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        }
-      }
-    },
-    {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
@@ -96,5 +75,6 @@ module.exports = function getMapping() {
   ]
     .concat(commonMappings.getColumnDateSeriesHandlingMappings())
     .concat(commonMappings.getColumnPrognosisMappings())
-    .concat(commonMappings.getColumnLabelColorMappings());
+    .concat(commonMappings.getColumnLabelColorMappings())
+    .concat(commonMappings.getHeightMappings());
 };

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -57,13 +57,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.barOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -258,7 +258,7 @@ function getBarLabelColorMappings() {
 function getHeightMappings() {
   return [
     {
-      path: "toolRuntimeConfig.size",
+      path: "toolRuntimeConfig.displayOptions.size",
       mapToSpec: function(size, spec, renderingInfoInput) {
         let aspectRatio;
         if (size === "prominent") {

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -276,6 +276,7 @@ function getHeightMappings() {
         if (renderingInfoInput.item.options.hideAxisLabel === false) {
           height = height + 20;
         }
+        objectPath.set(spec, "height", height);
       }
     }
   ];

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -9,10 +9,10 @@ function getLineDateSeriesHandlingMappings() {
   return [
     {
       path: "item.data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(itemData, spec, mappingData) {
+        const item = mappingData.item;
         if (
-          renderingInfoInput.dateFormat &&
+          mappingData.dateFormat &&
           item.options.lineChartOptions &&
           item.options.lineChartOptions.isStockChart !== true
         ) {
@@ -23,8 +23,8 @@ function getLineDateSeriesHandlingMappings() {
     },
     {
       path: "item.options.dateSeriesOptions.interval",
-      mapToSpec: function(interval, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(interval, spec, mappingData) {
+        const item = mappingData.item;
         // only use this option if we have a valid dateFormat
         if (spec.scales[0].type === "time") {
           if (process.env.FEAT_VARIABLE_HOUR_STEP === true) {
@@ -67,9 +67,9 @@ function getColumnDateSeriesHandlingMappings() {
   return [
     {
       path: "item.data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
-        if (renderingInfoInput.dateFormat) {
+      mapToSpec: function(itemData, spec, mappingData) {
+        const item = mappingData.item;
+        if (mappingData.dateFormat) {
           const d3format =
             intervals[item.options.dateSeriesOptions.interval].d3format;
 
@@ -97,9 +97,9 @@ function getBarDateSeriesHandlingMappings() {
   return [
     {
       path: "item.data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
-        if (renderingInfoInput.dateFormat) {
+      mapToSpec: function(itemData, spec, mappingData) {
+        const item = mappingData.item;
+        if (mappingData.dateFormat) {
           const d3format =
             intervals[item.options.dateSeriesOptions.interval].d3format;
 
@@ -127,7 +127,7 @@ function getColumnPrognosisMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, renderingInfoInput, id) {
+      mapToSpec: function(prognosisStart, spec, mappingData, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -176,7 +176,7 @@ function getBarPrognosisMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, renderingInfoInput, id) {
+      mapToSpec: function(prognosisStart, spec, mappingData, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -259,7 +259,7 @@ function getHeightMappings() {
   return [
     {
       path: "toolRuntimeConfig.displayOptions.size",
-      mapToSpec: function(size, spec, renderingInfoInput) {
+      mapToSpec: function(size, spec, mappingData) {
         let aspectRatio;
         if (size === "prominent") {
           aspectRatio = 9 / 16;
@@ -273,7 +273,7 @@ function getHeightMappings() {
           height = 240;
         }
         // increase the height if hideAxisLabel option is unchecked
-        if (renderingInfoInput.item.options.hideAxisLabel === false) {
+        if (mappingData.item.options.hideAxisLabel === false) {
           height = height + 20;
         }
         objectPath.set(spec, "height", height);

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -5,13 +5,14 @@ const d3 = {
   timeFormat: require("d3-time-format").timeFormat
 };
 
-function getLineDateSeriesHandlingMappings(config = {}) {
+function getLineDateSeriesHandlingMappings() {
   return [
     {
-      path: "data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data", // various settings that are not tied to an option
+      mapToSpec: function(itemData, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         if (
-          config.dateFormat &&
+          renderingInfoInput.dateFormat &&
           item.options.lineChartOptions &&
           item.options.lineChartOptions.isStockChart !== true
         ) {
@@ -21,8 +22,9 @@ function getLineDateSeriesHandlingMappings(config = {}) {
       }
     },
     {
-      path: "options.dateSeriesOptions.interval",
-      mapToSpec: function(interval, spec, item) {
+      path: "item.options.dateSeriesOptions.interval",
+      mapToSpec: function(interval, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         // only use this option if we have a valid dateFormat
         if (spec.scales[0].type === "time") {
           if (process.env.FEAT_VARIABLE_HOUR_STEP === true) {
@@ -61,12 +63,13 @@ function getLineDateSeriesHandlingMappings(config = {}) {
   ];
 }
 
-function getColumnDateSeriesHandlingMappings(config = {}) {
+function getColumnDateSeriesHandlingMappings() {
   return [
     {
-      path: "data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, item) {
-        if (config.dateFormat) {
+      path: "item.data", // various settings that are not tied to an option
+      mapToSpec: function(itemData, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
+        if (renderingInfoInput.dateFormat) {
           const d3format =
             intervals[item.options.dateSeriesOptions.interval].d3format;
 
@@ -90,12 +93,13 @@ function getColumnDateSeriesHandlingMappings(config = {}) {
   ];
 }
 
-function getBarDateSeriesHandlingMappings(config = {}) {
+function getBarDateSeriesHandlingMappings() {
   return [
     {
-      path: "data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, item) {
-        if (config.dateFormat) {
+      path: "item.data", // various settings that are not tied to an option
+      mapToSpec: function(itemData, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
+        if (renderingInfoInput.dateFormat) {
           const d3format =
             intervals[item.options.dateSeriesOptions.interval].d3format;
 
@@ -119,11 +123,11 @@ function getBarDateSeriesHandlingMappings(config = {}) {
   ];
 }
 
-function getColumnPrognosisMappings(config) {
+function getColumnPrognosisMappings() {
   return [
     {
-      path: "options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, item, id) {
+      path: "item.options.dateSeriesOptions.prognosisStart",
+      mapToSpec: function(prognosisStart, spec, renderingInfoInput, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -168,11 +172,11 @@ function getColumnPrognosisMappings(config) {
   ];
 }
 
-function getBarPrognosisMappings(config) {
+function getBarPrognosisMappings() {
   return [
     {
-      path: "options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, item, id) {
+      path: "item.options.dateSeriesOptions.prognosisStart",
+      mapToSpec: function(prognosisStart, spec, renderingInfoInput, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -215,11 +219,11 @@ function getBarPrognosisMappings(config) {
   ];
 }
 
-function getColumnLabelColorMappings(config) {
+function getColumnLabelColorMappings() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item, id) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         if (!spec.config.axis.labelColorDark) {
           return;
         }
@@ -233,11 +237,11 @@ function getColumnLabelColorMappings(config) {
   ];
 }
 
-function getBarLabelColorMappings(config) {
+function getBarLabelColorMappings() {
   return [
     {
       path: "data",
-      mapToSpec: function(itemData, spec, item, id) {
+      mapToSpec: function(itemData, spec) {
         if (!spec.config.axis.labelColorDark) {
           return;
         }

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -255,6 +255,32 @@ function getBarLabelColorMappings() {
   ];
 }
 
+function getHeightMappings() {
+  return [
+    {
+      path: "toolRuntimeConfig.size",
+      mapToSpec: function(size, spec, renderingInfoInput) {
+        let aspectRatio;
+        if (size === "prominent") {
+          aspectRatio = 9 / 16;
+        } else {
+          aspectRatio = 3 / 7;
+        }
+        let height = spec.width * aspectRatio;
+
+        // minimum height is 240px
+        if (height < 240) {
+          height = 240;
+        }
+        // increase the height if hideAxisLabel option is unchecked
+        if (renderingInfoInput.item.options.hideAxisLabel === false) {
+          height = height + 20;
+        }
+      }
+    }
+  ];
+}
+
 module.exports = {
   getLineDateSeriesHandlingMappings: getLineDateSeriesHandlingMappings,
   getColumnDateSeriesHandlingMappings: getColumnDateSeriesHandlingMappings,
@@ -262,5 +288,6 @@ module.exports = {
   getColumnPrognosisMappings: getColumnPrognosisMappings,
   getBarPrognosisMappings: getBarPrognosisMappings,
   getColumnLabelColorMappings: getColumnLabelColorMappings,
-  getBarLabelColorMappings: getBarLabelColorMappings
+  getBarLabelColorMappings: getBarLabelColorMappings,
+  getHeightMappings: getHeightMappings
 };

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -11,11 +11,11 @@ const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
 const textMetrics = require("vega").textMetrics;
 
-module.exports = function getMapping(config = {}) {
+module.exports = function getMapping() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.1.title", itemData[0][0]);
 
@@ -138,8 +138,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
@@ -148,12 +148,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.dotplotOptions.minValue",
-      mapToSpec: function(minValue, spec, item) {
+      path: "item.options.dotplotOptions.minValue",
+      mapToSpec: function(minValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(item.data);
+        const dataMinValue = dataHelpers.getMinValue(
+          renderingInfoInput.item.data
+        );
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -163,12 +165,14 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.dotplotOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.dotplotOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -178,8 +182,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.dotplotOptions.connectDots",
-      mapToSpec: function(connectDots, spec, item) {
+      path: "item.options.dotplotOptions.connectDots",
+      mapToSpec: function(connectDots, spec) {
         if (!connectDots) {
           return;
         }
@@ -212,8 +216,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.min",
-      mapToSpec: function(showMinAnnotation, spec, item) {
+      path: "item.options.annotations.min",
+      mapToSpec: function(showMinAnnotation, spec) {
         if (!showMinAnnotation) {
           return;
         }
@@ -250,8 +254,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.max",
-      mapToSpec: function(showMaxAnnotation, spec, item) {
+      path: "item.options.annotations.max",
+      mapToSpec: function(showMaxAnnotation, spec) {
         if (!showMaxAnnotation) {
           return;
         }
@@ -288,8 +292,8 @@ module.exports = function getMapping(config = {}) {
       }
     },
     {
-      path: "options.annotations.diff",
-      mapToSpec: function(showDiffAnnoation, spec, item) {
+      path: "item.options.annotations.diff",
+      mapToSpec: function(showDiffAnnoation, spec) {
         if (!showDiffAnnoation) {
           return;
         }
@@ -337,5 +341,5 @@ module.exports = function getMapping(config = {}) {
         spec.marks[0].marks[0].marks.push(diffTextMarksSpec);
       }
     }
-  ].concat(commonMappings.getBarLabelColorMappings(config));
+  ].concat(commonMappings.getBarLabelColorMappings());
 };

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -149,13 +149,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.dotplotOptions.minValue",
-      mapToSpec: function(minValue, spec, renderingInfoInput) {
+      mapToSpec: function(minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(
-          renderingInfoInput.item.data
-        );
+        const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -166,13 +164,11 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.dotplotOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -11,11 +11,11 @@ const d3 = {
   array: require("d3-array")
 };
 
-module.exports = function getMappings(config = {}) {
+module.exports = function getMappings() {
   return [
     {
-      path: "data",
-      mapToSpec: function(itemData, spec, item) {
+      path: "item.data",
+      mapToSpec: function(itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
@@ -52,8 +52,9 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.annotations",
-      mapToSpec: function(annotationOptions, spec, item) {
+      path: "item.options.annotations",
+      mapToSpec: function(annotationOptions, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         // this option is only available if we have exactly one data series
         if (item.data[0].length !== 2) {
           return;
@@ -160,8 +161,8 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec, item) {
+      path: "item.options.hideAxisLabel",
+      mapToSpec: function(hideAxisLabel, spec) {
         if (hideAxisLabel === true) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
@@ -170,12 +171,14 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.lineChartOptions.minValue",
-      mapToSpec: function(minValue, spec, item) {
+      path: "item.options.lineChartOptions.minValue",
+      mapToSpec: function(minValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(item.data);
+        const dataMinValue = dataHelpers.getMinValue(
+          renderingInfoInput.item.data
+        );
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -185,12 +188,14 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.lineChartOptions.maxValue",
-      mapToSpec: function(maxValue, spec, item) {
+      path: "item.options.lineChartOptions.maxValue",
+      mapToSpec: function(maxValue, spec, renderingInfoInput) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(item.data);
+        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(item.data);
+        const dataMaxValue = dataHelpers.getMaxValue(
+          renderingInfoInput.item.data
+        );
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -200,16 +205,16 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.lineChartOptions.reverseYScale",
-      mapToSpec: function(reverseYScale, spec, item) {
+      path: "item.options.lineChartOptions.reverseYScale",
+      mapToSpec: function(reverseYScale, spec) {
         if (reverseYScale === true) {
           objectPath.set(spec, "scales.1.reverse", true);
         }
       }
     },
     {
-      path: "options.lineChartOptions.lineInterpolation",
-      mapToSpec: function(interpolation, spec, item) {
+      path: "item.options.lineChartOptions.lineInterpolation",
+      mapToSpec: function(interpolation, spec) {
         if (interpolation) {
           objectPath.set(
             spec,
@@ -220,7 +225,7 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.dateSeriesOptions.prognosisStart",
+      path: "item.options.dateSeriesOptions.prognosisStart",
       mapToSpec: function(prognosisStart, spec) {
         if (prognosisStart === null) {
           return;
@@ -245,8 +250,9 @@ module.exports = function getMappings(config = {}) {
       }
     },
     {
-      path: "options.lineChartOptions.isStockChart",
-      mapToSpec: function(isStockChart, spec, item) {
+      path: "item.options.lineChartOptions.isStockChart",
+      mapToSpec: function(isStockChart, spec, renderingInfoInput) {
+        const item = renderingInfoInput.item;
         if (!isStockChart) {
           return;
         }
@@ -303,5 +309,5 @@ module.exports = function getMappings(config = {}) {
         objectPath.set(spec, "axes.0.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
       }
     }
-  ].concat(commonMappings.getLineDateSeriesHandlingMappings(config));
+  ].concat(commonMappings.getLineDateSeriesHandlingMappings());
 };

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -53,8 +53,8 @@ module.exports = function getMappings() {
     },
     {
       path: "item.options.annotations",
-      mapToSpec: function(annotationOptions, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(annotationOptions, spec, mappingData) {
+        const item = mappingData.item;
         // this option is only available if we have exactly one data series
         if (item.data[0].length !== 2) {
           return;
@@ -172,13 +172,11 @@ module.exports = function getMappings() {
     },
     {
       path: "item.options.lineChartOptions.minValue",
-      mapToSpec: function(minValue, spec, renderingInfoInput) {
+      mapToSpec: function(minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMinValue = dataHelpers.getMinValue(
-          renderingInfoInput.item.data
-        );
+        const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
           minValue = dataMinValue;
         }
@@ -189,13 +187,11 @@ module.exports = function getMappings() {
     },
     {
       path: "item.options.lineChartOptions.maxValue",
-      mapToSpec: function(maxValue, spec, renderingInfoInput) {
+      mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(renderingInfoInput.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
-        const dataMaxValue = dataHelpers.getMaxValue(
-          renderingInfoInput.item.data
-        );
+        const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
           maxValue = dataMaxValue;
         }
@@ -251,8 +247,8 @@ module.exports = function getMappings() {
     },
     {
       path: "item.options.lineChartOptions.isStockChart",
-      mapToSpec: function(isStockChart, spec, renderingInfoInput) {
-        const item = renderingInfoInput.item;
+      mapToSpec: function(isStockChart, spec, mappingData) {
+        const item = mappingData.item;
         if (!isStockChart) {
           return;
         }

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -61,14 +61,14 @@ module.exports = function getMappings() {
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         } else {
           // Aspect ratio 7:3
           height = spec.width * (3 / 7);
           if (height < 240) {
             height = 240;
           }
-          objectPath.set(spec, "height", height);
+          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
         }
       }
     },

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -52,6 +52,27 @@ module.exports = function getMappings() {
       }
     },
     {
+      path: "toolRuntimeConfig.displayOptions.size",
+      mapToSpec: function(size, spec) {
+        let height;
+        if (size === "prominent") {
+          // Aspect ratio 16:9
+          height = spec.width * (9 / 16);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        } else {
+          // Aspect ratio 7:3
+          height = spec.width * (3 / 7);
+          if (height < 240) {
+            height = 240;
+          }
+          objectPath.set(spec, "height", height);
+        }
+      }
+    },
+    {
       path: "item.options.annotations",
       mapToSpec: function(annotationOptions, spec, renderingInfoInput) {
         const item = renderingInfoInput.item;

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -52,27 +52,6 @@ module.exports = function getMappings() {
       }
     },
     {
-      path: "toolRuntimeConfig.displayOptions.size",
-      mapToSpec: function(size, spec) {
-        let height;
-        if (size === "prominent") {
-          // Aspect ratio 16:9
-          height = spec.width * (9 / 16);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        } else {
-          // Aspect ratio 7:3
-          height = spec.width * (3 / 7);
-          if (height < 240) {
-            height = 240;
-          }
-          objectPath.set(spec, "height", height + 20); // increase the height because we need space for the axis title
-        }
-      }
-    },
-    {
       path: "item.options.annotations",
       mapToSpec: function(annotationOptions, spec, renderingInfoInput) {
         const item = renderingInfoInput.item;
@@ -330,5 +309,7 @@ module.exports = function getMappings() {
         objectPath.set(spec, "axes.0.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
       }
     }
-  ].concat(commonMappings.getLineDateSeriesHandlingMappings());
+  ]
+    .concat(commonMappings.getLineDateSeriesHandlingMappings())
+    .concat(commonMappings.getHeightMappings());
 };

--- a/helpers/data.js
+++ b/helpers/data.js
@@ -31,7 +31,8 @@ function getDataWithStringsCastedToFloats(data) {
   });
 }
 
-function getLongestDataLabel(item, config, transposed = false) {
+function getLongestDataLabel(renderingInfoInput, transposed = false) {
+  const item = renderingInfoInput.item;
   data = clone(item.data);
   if (transposed) {
     data = array2d.transpose(data);
@@ -40,7 +41,7 @@ function getLongestDataLabel(item, config, transposed = false) {
   titleRow.shift();
   return titleRow
     .map(label => {
-      if (!config.dateFormat) {
+      if (!renderingInfoInput.dateFormat) {
         return label;
       }
       // we have a date format, so we need to format the labels
@@ -53,7 +54,7 @@ function getLongestDataLabel(item, config, transposed = false) {
     })
     .reduce((prev, current) => {
       // if we have a date series, we need to format the label here
-      if (config.dateFormat) {
+      if (renderingInfoInput.dateFormat) {
       }
 
       if (prev.length > current.length) {

--- a/helpers/data.js
+++ b/helpers/data.js
@@ -31,8 +31,8 @@ function getDataWithStringsCastedToFloats(data) {
   });
 }
 
-function getLongestDataLabel(renderingInfoInput, transposed = false) {
-  const item = renderingInfoInput.item;
+function getLongestDataLabel(mappingData, transposed = false) {
+  const item = mappingData.item;
   data = clone(item.data);
   if (transposed) {
     data = array2d.transpose(data);
@@ -41,7 +41,7 @@ function getLongestDataLabel(renderingInfoInput, transposed = false) {
   titleRow.shift();
   return titleRow
     .map(label => {
-      if (!renderingInfoInput.dateFormat) {
+      if (!mappingData.dateFormat) {
         return label;
       }
       // we have a date format, so we need to format the labels
@@ -54,7 +54,7 @@ function getLongestDataLabel(renderingInfoInput, transposed = false) {
     })
     .reduce((prev, current) => {
       // if we have a date series, we need to format the label here
-      if (renderingInfoInput.dateFormat) {
+      if (mappingData.dateFormat) {
       }
 
       if (prev.length > current.length) {

--- a/helpers/itemVegaMapping.js
+++ b/helpers/itemVegaMapping.js
@@ -1,11 +1,11 @@
 const clone = require("clone");
 const objectPath = require("object-path");
 
-function getSpecWithMappedItem(item, id, chartType, spec, config = {}) {
+function getMappedSpec(id, chartType, spec, renderingInfoInput) {
   const modifiedSpec = clone(spec);
   let mappings;
   try {
-    mappings = require(`../chartTypes/${chartType}/mapping.js`)(config);
+    mappings = require(`../chartTypes/${chartType}/mapping.js`)();
   } catch (err) {
     throw new Error(
       `no or no valid type mapping implemented for type ${chartType}`
@@ -13,11 +13,11 @@ function getSpecWithMappedItem(item, id, chartType, spec, config = {}) {
   }
   try {
     for (const mapping of mappings) {
-      const itemValue = objectPath.get(item, mapping.path);
+      const itemValue = objectPath.get(renderingInfoInput, mapping.path);
       if (itemValue === undefined) {
         continue;
       }
-      mapping.mapToSpec(itemValue, modifiedSpec, item, id);
+      mapping.mapToSpec(itemValue, modifiedSpec, renderingInfoInput, id);
     }
   } catch (err) {
     throw err;
@@ -26,5 +26,5 @@ function getSpecWithMappedItem(item, id, chartType, spec, config = {}) {
 }
 
 module.exports = {
-  getSpecWithMappedItem: getSpecWithMappedItem
+  getMappedSpec: getMappedSpec
 };

--- a/helpers/itemVegaMapping.js
+++ b/helpers/itemVegaMapping.js
@@ -1,7 +1,7 @@
 const clone = require("clone");
 const objectPath = require("object-path");
 
-function getMappedSpec(id, chartType, spec, renderingInfoInput) {
+function getMappedSpec(id, chartType, spec, mappingData) {
   const modifiedSpec = clone(spec);
   let mappings;
   try {
@@ -13,11 +13,11 @@ function getMappedSpec(id, chartType, spec, renderingInfoInput) {
   }
   try {
     for (const mapping of mappings) {
-      const itemValue = objectPath.get(renderingInfoInput, mapping.path);
+      const itemValue = objectPath.get(mappingData, mapping.path);
       if (itemValue === undefined) {
         continue;
       }
-      mapping.mapToSpec(itemValue, modifiedSpec, renderingInfoInput, id);
+      mapping.mapToSpec(itemValue, modifiedSpec, mappingData, id);
     }
   } catch (err) {
     throw err;

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -6,6 +6,22 @@
     "hideTitle": {
       "type": "boolean",
       "title": "Titel ausblenden"
+    },
+    "size": {
+      "titel": "Gewicht",
+      "type": "string",
+      "default": "basic",
+      "enum": ["basic", "prominent"],
+      "Q:options": {
+        "enum_titles": ["standard", "prominent"],
+        "availabilityChecks": [
+          {
+            "type": "ToolEndpoint",
+            "withData": true,
+            "endpoint": "option-availability/displayWeight"
+          }
+        ]
+      }
     }
   }
 }

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -13,6 +13,7 @@
       "default": "basic",
       "enum": ["basic", "prominent"],
       "Q:options": {
+        "selectType": "radio",
         "enum_titles": ["standard", "prominent"],
         "availabilityChecks": [
           {

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -8,7 +8,7 @@
       "title": "Titel ausblenden"
     },
     "size": {
-      "title": "Gewicht",
+      "title": "Gewichtung",
       "type": "string",
       "default": "basic",
       "enum": ["basic", "prominent"],

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -8,7 +8,7 @@
       "title": "Titel ausblenden"
     },
     "size": {
-      "titel": "Gewicht",
+      "title": "Gewicht",
       "type": "string",
       "default": "basic",
       "enum": ["basic", "prominent"],

--- a/routes/option-availability.js
+++ b/routes/option-availability.js
@@ -6,8 +6,7 @@ const getFirstColumnSerie = require("../helpers/dateSeries.js")
 const getChartTypeForItemAndWidth = require("../helpers/chartType.js")
   .getChartTypeForItemAndWidth;
 
-const configuredDivergingColorSchemes = require('../helpers/colorSchemes.js').getConfiguredDivergingColorSchemes();
-
+const configuredDivergingColorSchemes = require("../helpers/colorSchemes.js").getConfiguredDivergingColorSchemes();
 
 function isBarChart(item) {
   return (
@@ -76,7 +75,7 @@ module.exports = {
       } catch (e) {
         return {
           available: false
-        }
+        };
       }
     }
 
@@ -97,7 +96,9 @@ module.exports = {
     if (request.params.optionName === "arrow.colorScheme") {
       return {
         available:
-          isArrowChart(request.payload) && hasNoCustomVegaSpec(request.payload) && configuredDivergingColorSchemes
+          isArrowChart(request.payload) &&
+          hasNoCustomVegaSpec(request.payload) &&
+          configuredDivergingColorSchemes
       };
     }
 
@@ -128,7 +129,10 @@ module.exports = {
       };
     }
 
-    if (request.params.optionName === "chartType" || request.params.optionName === "hideAxisLabel") {
+    if (
+      request.params.optionName === "chartType" ||
+      request.params.optionName === "hideAxisLabel"
+    ) {
       return {
         available: hasNoCustomVegaSpec(request.payload)
       };
@@ -140,7 +144,8 @@ module.exports = {
       request.params.optionName === "colorOverwrite"
     ) {
       return {
-        available: hasNoCustomVegaSpec(request.payload) && !isArrowChart(request.payload)
+        available:
+          hasNoCustomVegaSpec(request.payload) && !isArrowChart(request.payload)
       };
     }
 
@@ -158,7 +163,10 @@ module.exports = {
         available = true;
       }
 
-      if (isArrowChart(request.payload) && hasNoCustomVegaSpec(request.payload)) {
+      if (
+        isArrowChart(request.payload) &&
+        hasNoCustomVegaSpec(request.payload)
+      ) {
         available = true;
       }
 
@@ -194,6 +202,17 @@ module.exports = {
     if (request.params.optionName === "annotations.diff") {
       return {
         available: isDotplot(request.payload) || isArrowChart(request.payload)
+      };
+    }
+
+    if (request.params.optionName === "displayWeight") {
+      const options = request.payload.options;
+      return {
+        available:
+          isLineChart(request.payload) ||
+          ((options.chartType === "Bar" ||
+            options.chartType === "StackedBar") &&
+            options.barOptions.isBarChart === false)
       };
     }
 

--- a/routes/rendering-info/web-svg.js
+++ b/routes/rendering-info/web-svg.js
@@ -3,8 +3,7 @@ const Boom = require("boom");
 const vega = require("vega");
 const clone = require("clone");
 const deepmerge = require("deepmerge");
-const getSpecWithMappedItem = require("../../helpers/itemVegaMapping.js")
-  .getSpecWithMappedItem;
+const getMappedSpec = require("../../helpers/itemVegaMapping.js").getMappedSpec;
 const vegaConfigHelper = require("../../helpers/vegaConfig.js");
 const getDataWithStringsCastedToFloats = require("../../helpers/data.js")
   .getDataWithStringsCastedToFloats;
@@ -52,28 +51,31 @@ function getSpecConfig(item, baseConfig, toolRuntimeConfig) {
   return config;
 }
 
-async function getSpec(item, width, toolRuntimeConfig, chartType, id) {
-  const mappingConfig = {
-    width: width,
-    colorSchemes: toolRuntimeConfig.colorSchemes
+async function getSpec(id, width, chartType, item, toolRuntimeConfig) {
+  const renderingInfoInput = {
+    item: item,
+    toolRuntimeConfig: toolRuntimeConfig
   };
-
   const chartTypeConfig = require(`../../chartTypes/${chartType}/config.js`);
   if (chartTypeConfig.data.handleDateSeries) {
     // if we have a date series, we change the date values to date objects
-    // and set the detected dateFormat to the mappingConfig to be used within the mapping functions
+    // and set the detected dateFormat to the renderingInfoInput to be used within the mapping functions
     if (dateSeries.isDateSeriesData(item.data)) {
-      mappingConfig.dateFormat = dateSeries.getDateFormatForData(item.data);
-      item.data = dateSeries.getDataWithDateParsed(item.data);
+      renderingInfoInput.dateFormat = dateSeries.getDateFormatForData(
+        renderingInfoInput.item.data
+      );
+      renderingInfoInput.item.data = dateSeries.getDataWithDateParsed(
+        renderingInfoInput.item.data
+      );
     }
   }
 
   const templateSpec = require(`../../chartTypes/${chartType}/vega-spec.json`);
 
   templateSpec.config = getSpecConfig(
-    item,
+    renderingInfoInput.item,
     templateSpec.config,
-    toolRuntimeConfig
+    renderingInfoInput.toolRuntimeConfig
   );
 
   // set the size to the spec
@@ -82,20 +84,14 @@ async function getSpec(item, width, toolRuntimeConfig, chartType, id) {
   // this will be the compiled spec from template and mapping
   let spec;
   try {
-    spec = getSpecWithMappedItem(
-      item,
-      id,
-      chartType,
-      templateSpec,
-      mappingConfig
-    );
+    spec = getMappedSpec(id, chartType, templateSpec, renderingInfoInput);
   } catch (err) {
     throw new Boom(err);
   }
   return spec;
 }
 
-async function getSvg(item, width, toolRuntimeConfig, id, request) {
+async function getSvg(id, request, width, item, toolRuntimeConfig) {
   // first and foremost: cast all the floats in strings to actual floats
   item.data = getDataWithStringsCastedToFloats(item.data);
 
@@ -113,7 +109,7 @@ async function getSvg(item, width, toolRuntimeConfig, id, request) {
     spec.data[0].values = clone(item.data);
   } else if (item.options.chartType) {
     try {
-      spec = await getSpec(item, width, toolRuntimeConfig, chartType, id);
+      spec = await getSpec(id, width, chartType, item, toolRuntimeConfig);
     } catch (err) {
       console.log(err);
       throw err;
@@ -213,11 +209,11 @@ module.exports = {
 
     const webSvg = {
       markup: await getSvg(
-        item,
-        request.query.width,
-        toolRuntimeConfig,
         request.query.id,
-        request
+        request,
+        request.query.width,
+        item,
+        toolRuntimeConfig
       )
     };
 

--- a/routes/rendering-info/web-svg.js
+++ b/routes/rendering-info/web-svg.js
@@ -52,20 +52,20 @@ function getSpecConfig(item, baseConfig, toolRuntimeConfig) {
 }
 
 async function getSpec(id, width, chartType, item, toolRuntimeConfig) {
-  const renderingInfoInput = {
+  const mappingData = {
     item: item,
     toolRuntimeConfig: toolRuntimeConfig
   };
   const chartTypeConfig = require(`../../chartTypes/${chartType}/config.js`);
   if (chartTypeConfig.data.handleDateSeries) {
     // if we have a date series, we change the date values to date objects
-    // and set the detected dateFormat to the renderingInfoInput to be used within the mapping functions
+    // and set the detected dateFormat to the mappingData to be used within the mapping functions
     if (dateSeries.isDateSeriesData(item.data)) {
-      renderingInfoInput.dateFormat = dateSeries.getDateFormatForData(
-        renderingInfoInput.item.data
+      mappingData.dateFormat = dateSeries.getDateFormatForData(
+        mappingData.item.data
       );
-      renderingInfoInput.item.data = dateSeries.getDataWithDateParsed(
-        renderingInfoInput.item.data
+      mappingData.item.data = dateSeries.getDataWithDateParsed(
+        mappingData.item.data
       );
     }
   }
@@ -73,9 +73,9 @@ async function getSpec(id, width, chartType, item, toolRuntimeConfig) {
   const templateSpec = require(`../../chartTypes/${chartType}/vega-spec.json`);
 
   templateSpec.config = getSpecConfig(
-    renderingInfoInput.item,
+    mappingData.item,
     templateSpec.config,
-    renderingInfoInput.toolRuntimeConfig
+    mappingData.toolRuntimeConfig
   );
 
   // set the size to the spec
@@ -84,7 +84,7 @@ async function getSpec(id, width, chartType, item, toolRuntimeConfig) {
   // this will be the compiled spec from template and mapping
   let spec;
   try {
-    spec = getMappedSpec(id, chartType, templateSpec, renderingInfoInput);
+    spec = getMappedSpec(id, chartType, templateSpec, mappingData);
   } catch (err) {
     throw new Boom(err);
   }

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -110,8 +110,14 @@ module.exports = {
           axis: request.payload.toolRuntimeConfig.axis,
           text: request.payload.toolRuntimeConfig.text,
           colorSchemes: request.payload.toolRuntimeConfig.colorSchemes,
-          size: request.payload.toolRuntimeConfig.displayOptions.size
+          size: "basic"
         };
+
+        // set size property if displayOptions are defined
+        const displayOptions = request.payload.toolRuntimeConfig.displayOptions;
+        if (displayOptions && displayOptions.size) {
+          toolRuntimeConfigForWebSVG.size = displayOptions.size;
+        }
       }
 
       let requestMethod;

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -109,7 +109,8 @@ module.exports = {
         toolRuntimeConfigForWebSVG = {
           axis: request.payload.toolRuntimeConfig.axis,
           text: request.payload.toolRuntimeConfig.text,
-          colorSchemes: request.payload.toolRuntimeConfig.colorSchemes
+          colorSchemes: request.payload.toolRuntimeConfig.colorSchemes,
+          size: request.payload.toolRuntimeConfig.displayOptions.size
         };
       }
 

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -110,14 +110,8 @@ module.exports = {
           axis: request.payload.toolRuntimeConfig.axis,
           text: request.payload.toolRuntimeConfig.text,
           colorSchemes: request.payload.toolRuntimeConfig.colorSchemes,
-          size: "basic"
+          displayOptions: request.payload.toolRuntimeConfig.displayOptions || {}
         };
-
-        // set size property if displayOptions are defined
-        const displayOptions = request.payload.toolRuntimeConfig.displayOptions;
-        if (displayOptions && displayOptions.size) {
-          toolRuntimeConfigForWebSVG.size = displayOptions.size;
-        }
       }
 
       let requestMethod;


### PR DESCRIPTION
- This PR implements the height calculation based on displayOption `size`
- This branch is deployed on staging, so it can be tested in Staging LivingDocs -> https://edit-stage.nzz.ch/articles/15611/edit/add
  - The `size` option is only available for charttypes `line`, `column` and `stacked-column`
  - In a regular article (width of 560px) charts with `size` `basic` have a height of `240px` and with axis label `260px`
  - With `size` `prominent` they have a height of `315px` and with axis label `335px`
- Closes https://github.com/nzzdev/Q-chart/issues/99