### PR TITLE
Release 1.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/routes/rendering-info/web-svg.js
+++ b/routes/rendering-info/web-svg.js
@@ -54,7 +54,8 @@ function getSpecConfig(item, baseConfig, toolRuntimeConfig) {
 async function getSpec(id, width, chartType, item, toolRuntimeConfig) {
   const mappingData = {
     item: item,
-    toolRuntimeConfig: toolRuntimeConfig
+    toolRuntimeConfig: toolRuntimeConfig,
+    width: width
   };
   const chartTypeConfig = require(`../../chartTypes/${chartType}/config.js`);
   if (chartTypeConfig.data.handleDateSeries) {


### PR DESCRIPTION
- This is a bugfix release
- Fixes a problem with bar charts with single columns. The label was not shown above the bar because the width was not passed to `mappingData`