### PR TITLE
Adjust the schema of availability-checks, notification-checks and dynamic-enums

### DIFF
--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -18,7 +18,7 @@
         "availabilityChecks": [
           {
             "type": "ToolEndpoint",
-            "withData": true,
+            "data": ["options.chartType", "options.barOptions.isBarChart"],
             "endpoint": "option-availability/displayWeight"
           }
         ]

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -18,8 +18,10 @@
         "availabilityChecks": [
           {
             "type": "ToolEndpoint",
-            "endpoint": "option-availability/displayWeight",
-            "fields": ["options.chartType", "options.barOptions.isBarChart"]
+            "config": {
+              "endpoint": "option-availability/displayWeight",
+              "fields": ["options.chartType", "options.barOptions.isBarChart"]
+            }
           }
         ]
       }

--- a/resources/display-options-schema.json
+++ b/resources/display-options-schema.json
@@ -18,8 +18,8 @@
         "availabilityChecks": [
           {
             "type": "ToolEndpoint",
-            "data": ["options.chartType", "options.barOptions.isBarChart"],
-            "endpoint": "option-availability/displayWeight"
+            "endpoint": "option-availability/displayWeight",
+            "fields": ["options.chartType", "options.barOptions.isBarChart"]
           }
         ]
       }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -25,7 +25,7 @@
         "notificationChecks": [
           {
             "type": "EmptyData",
-            "data": ["data"],
+            "fields": ["data"],
             "priority": {
               "type": "low",
               "value": 1
@@ -33,7 +33,7 @@
           },
           {
             "type": "HasColumnTitles",
-            "data": ["data"],
+            "fields": ["data"],
             "priority": {
               "type": "medium",
               "value": 1
@@ -41,7 +41,7 @@
           },
           {
             "type": "TooManyColumns",
-            "data": ["data"],
+            "fields": ["data"],
             "priority": {
               "type": "medium",
               "value": 2
@@ -53,10 +53,13 @@
           {
             "type": "ToolEndpoint",
             "endpoint": "notification/unsupportedDateFormat",
-            "data": ["data"],
+            "fields": ["data"],
             "priority": {
               "type": "medium",
               "value": 3
+            },
+            "options": {
+              "limit": 8
             }
           }
         ]
@@ -147,7 +150,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["vegaSpec"],
+                "fields": ["vegaSpec"],
                 "endpoint": "option-availability/chartType"
               }
             ],
@@ -155,7 +158,7 @@
               {
                 "type": "ToolEndpoint",
                 "endpoint": "notification/shouldBeBarChart",
-                "data": ["data", "options.chartType"],
+                "fields": ["data", "options.chartType"],
                 "priority": {
                   "type": "medium",
                   "value": 3
@@ -167,7 +170,7 @@
               {
                 "type": "ToolEndpoint",
                 "endpoint": "notification/shouldBeLineChart",
-                "data": ["data", "options.chartType"],
+                "fields": ["data", "options.chartType"],
                 "options": {
                   "limit": 40
                 },
@@ -199,7 +202,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["vegaSpec", "options.chartType"],
+                "fields": ["vegaSpec", "options.chartType"],
                 "endpoint": "option-availability/highlightDataSeries"
               }
             ]
@@ -213,7 +216,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["vegaSpec"],
+                "fields": ["vegaSpec"],
                 "endpoint": "option-availability/hideAxisLabel"
               }
             ],
@@ -221,7 +224,7 @@
               {
                 "type": "ToolEndpoint",
                 "endpoint": "notification/hideAxisLabel",
-                "data": ["data", "options.hideAxisLabel"],
+                "fields": ["data", "options.hideAxisLabel"],
                 "priority": {
                   "type": "medium",
                   "value": 5
@@ -241,7 +244,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType"],
+                    "fields": ["options.chartType"],
                     "endpoint": "option-availability/annotations.first"
                   }
                 ]
@@ -254,7 +257,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType"],
+                    "fields": ["options.chartType"],
                     "endpoint": "option-availability/annotations.last"
                   }
                 ]
@@ -267,7 +270,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType"],
+                    "fields": ["options.chartType"],
                     "endpoint": "option-availability/annotations.max"
                   }
                 ]
@@ -280,7 +283,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType"],
+                    "fields": ["options.chartType"],
                     "endpoint": "option-availability/annotations.min"
                   }
                 ]
@@ -293,7 +296,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType"],
+                    "fields": ["options.chartType"],
                     "endpoint": "option-availability/annotations.diff"
                   }
                 ]
@@ -304,7 +307,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["options.chartType", "vegaSpec", "data"],
+                "fields": ["options.chartType", "vegaSpec", "data"],
                 "endpoint": "option-availability/annotations"
               }
             ]
@@ -317,7 +320,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["options.chartType", "vegaSpec"],
+                "fields": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/bar"
               }
             ]
@@ -332,7 +335,7 @@
                   {
                     "type": "ToolEndpoint",
                     "endpoint": "notification/shouldBeBars",
-                    "data": [
+                    "fields": [
                       "data",
                       "options.chartType",
                       "options.barOptions.isBarChart",
@@ -357,7 +360,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": [
+                    "fields": [
                       "options.chartType",
                       "options.barOptions.isBarChart",
                       "vegaSpec"
@@ -380,7 +383,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": [
+                "fields": [
                   "data",
                   "vegaSpec",
                   "options.chartType",
@@ -434,7 +437,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["options.chartType", "vegaSpec"],
+                "fields": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/line"
               }
             ]
@@ -475,7 +478,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "data": ["data", "options.chartType", "vegaSpec"],
+                    "fields": ["data", "options.chartType", "vegaSpec"],
                     "endpoint": "option-availability/line.isStockChart"
                   }
                 ]
@@ -491,7 +494,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["options.chartType", "vegaSpec"],
+                "fields": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/dotplot"
               }
             ]
@@ -518,7 +521,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "data": ["options.chartType", "vegaSpec"],
+                "fields": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/arrow"
               }
             ]
@@ -544,7 +547,7 @@
                   },
                   {
                     "type": "ToolEndpoint",
-                    "data": ["options.chartType", "vegaSpec"],
+                    "fields": ["options.chartType", "vegaSpec"],
                     "endpoint": "option-availability/arrow.colorScheme"
                   }
                 ]
@@ -563,7 +566,7 @@
               },
               {
                 "type": "ToolEndpoint",
-                "data": ["vegaSpec", "options.chartType"],
+                "fields": ["vegaSpec", "options.chartType"],
                 "endpoint": "option-availability/colorOverwrite"
               }
             ],

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -25,7 +25,9 @@
         "notificationChecks": [
           {
             "type": "EmptyData",
-            "fields": ["data"],
+            "config": {
+              "fields": ["data"]
+            },
             "priority": {
               "type": "low",
               "value": 1
@@ -33,7 +35,9 @@
           },
           {
             "type": "HasColumnTitles",
-            "fields": ["data"],
+            "config": {
+              "fields": ["data"]
+            },
             "priority": {
               "type": "medium",
               "value": 1
@@ -41,25 +45,29 @@
           },
           {
             "type": "TooManyColumns",
-            "fields": ["data"],
+            "config": {
+              "fields": ["data"],
+              "options": {
+                "limit": 8
+              }
+            },
             "priority": {
               "type": "medium",
               "value": 2
-            },
-            "options": {
-              "limit": 8
             }
           },
           {
             "type": "ToolEndpoint",
-            "endpoint": "notification/unsupportedDateFormat",
-            "fields": ["data"],
+            "config": {
+              "endpoint": "notification/unsupportedDateFormat",
+              "fields": ["data"],
+              "options": {
+                "limit": 8
+              }
+            },
             "priority": {
               "type": "medium",
               "value": 3
-            },
-            "options": {
-              "limit": 8
             }
           }
         ]
@@ -92,7 +100,9 @@
         "availabilityChecks": [
           {
             "type": "UserHasRole",
-            "role": "expert-chart"
+            "config": {
+              "role": "expert-chart"
+            }
           }
         ]
       }
@@ -150,29 +160,35 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["vegaSpec"],
-                "endpoint": "option-availability/chartType"
+                "config": {
+                  "endpoint": "option-availability/chartType",
+                  "fields": ["vegaSpec"]
+                }
               }
             ],
             "notificationChecks": [
               {
                 "type": "ToolEndpoint",
-                "endpoint": "notification/shouldBeBarChart",
-                "fields": ["data", "options.chartType"],
+                "config": {
+                  "endpoint": "notification/shouldBeBarChart",
+                  "fields": ["data", "options.chartType"],
+                  "options": {
+                    "limit": 2
+                  }
+                },
                 "priority": {
                   "type": "medium",
                   "value": 3
-                },
-                "options": {
-                  "limit": 2
                 }
               },
               {
                 "type": "ToolEndpoint",
-                "endpoint": "notification/shouldBeLineChart",
-                "fields": ["data", "options.chartType"],
-                "options": {
-                  "limit": 40
+                "config": {
+                  "endpoint": "notification/shouldBeLineChart",
+                  "fields": ["data", "options.chartType"],
+                  "options": {
+                    "limit": 40
+                  }
                 },
                 "priority": {
                   "type": "medium",
@@ -202,8 +218,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["vegaSpec", "options.chartType"],
-                "endpoint": "option-availability/highlightDataSeries"
+                "config": {
+                  "endpoint": "option-availability/highlightDataSeries",
+                  "fields": ["vegaSpec", "options.chartType"]
+                }
               }
             ]
           }
@@ -216,15 +234,19 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["vegaSpec"],
-                "endpoint": "option-availability/hideAxisLabel"
+                "config": {
+                  "endpoint": "option-availability/hideAxisLabel",
+                  "fields": ["vegaSpec"]
+                }
               }
             ],
             "notificationChecks": [
               {
                 "type": "ToolEndpoint",
-                "endpoint": "notification/hideAxisLabel",
-                "fields": ["data", "options.hideAxisLabel"],
+                "config": {
+                  "endpoint": "notification/hideAxisLabel",
+                  "fields": ["data", "options.hideAxisLabel"]
+                },
                 "priority": {
                   "type": "medium",
                   "value": 5
@@ -244,8 +266,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType"],
-                    "endpoint": "option-availability/annotations.first"
+                    "config": {
+                      "endpoint": "option-availability/annotations.first",
+                      "fields": ["options.chartType"]
+                    }
                   }
                 ]
               }
@@ -257,8 +281,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType"],
-                    "endpoint": "option-availability/annotations.last"
+                    "config": {
+                      "endpoint": "option-availability/annotations.last",
+                      "fields": ["options.chartType"]
+                    }
                   }
                 ]
               }
@@ -270,8 +296,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType"],
-                    "endpoint": "option-availability/annotations.max"
+                    "config": {
+                      "endpoint": "option-availability/annotations.max",
+                      "fields": ["options.chartType"]
+                    }
                   }
                 ]
               }
@@ -283,8 +311,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType"],
-                    "endpoint": "option-availability/annotations.min"
+                    "config": {
+                      "endpoint": "option-availability/annotations.min",
+                      "fields": ["options.chartType"]
+                    }
                   }
                 ]
               }
@@ -296,8 +326,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType"],
-                    "endpoint": "option-availability/annotations.diff"
+                    "config": {
+                      "endpoint": "option-availability/annotations.diff",
+                      "fields": ["options.chartType"]
+                    }
                   }
                 ]
               }
@@ -307,8 +339,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["options.chartType", "vegaSpec", "data"],
-                "endpoint": "option-availability/annotations"
+                "config": {
+                  "endpoint": "option-availability/annotations",
+                  "fields": ["options.chartType", "vegaSpec", "data"]
+                }
               }
             ]
           }
@@ -320,8 +354,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["options.chartType", "vegaSpec"],
-                "endpoint": "option-availability/bar"
+                "config": {
+                  "endpoint": "option-availability/bar",
+                  "fields": ["options.chartType", "vegaSpec"]
+                }
               }
             ]
           },
@@ -334,19 +370,21 @@
                 "notificationChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "endpoint": "notification/shouldBeBars",
-                    "fields": [
-                      "data",
-                      "options.chartType",
-                      "options.barOptions.isBarChart",
-                      "options.barOptions.forceBarsOnSmall"
-                    ],
+                    "config": {
+                      "endpoint": "notification/shouldBeBars",
+                      "fields": [
+                        "data",
+                        "options.chartType",
+                        "options.barOptions.isBarChart",
+                        "options.barOptions.forceBarsOnSmall"
+                      ],
+                      "options": {
+                        "limit": 8
+                      }
+                    },
                     "priority": {
                       "type": "medium",
                       "value": 6
-                    },
-                    "options": {
-                      "limit": 8
                     }
                   }
                 ]
@@ -360,12 +398,14 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": [
-                      "options.chartType",
-                      "options.barOptions.isBarChart",
-                      "vegaSpec"
-                    ],
-                    "endpoint": "option-availability/forceBarsOnSmall"
+                    "config": {
+                      "endpoint": "option-availability/forceBarsOnSmall",
+                      "fields": [
+                        "options.chartType",
+                        "options.barOptions.isBarChart",
+                        "vegaSpec"
+                      ]
+                    }
                   }
                 ]
               }
@@ -383,14 +423,16 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": [
-                  "data",
-                  "vegaSpec",
-                  "options.chartType",
-                  "options.barOptions.isBarChart",
-                  "options.barOptions.forceBarsOnSmall"
-                ],
-                "endpoint": "option-availability/dateseries"
+                "config": {
+                  "endpoint": "option-availability/dateseries",
+                  "fields": [
+                    "data",
+                    "vegaSpec",
+                    "options.chartType",
+                    "options.barOptions.isBarChart",
+                    "options.barOptions.forceBarsOnSmall"
+                  ]
+                }
               }
             ]
           },
@@ -437,8 +479,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["options.chartType", "vegaSpec"],
-                "endpoint": "option-availability/line"
+                "config": {
+                  "endpoint": "option-availability/line",
+                  "fields": ["options.chartType", "vegaSpec"]
+                }
               }
             ]
           },
@@ -465,7 +509,9 @@
                 "availabilityChecks": [
                   {
                     "type": "UserHasRole",
-                    "role": "expert-chart"
+                    "config": {
+                      "role": "expert-chart"
+                    }
                   }
                 ]
               }
@@ -478,8 +524,10 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["data", "options.chartType", "vegaSpec"],
-                    "endpoint": "option-availability/line.isStockChart"
+                    "config": {
+                      "endpoint": "option-availability/line.isStockChart",
+                      "fields": ["data", "options.chartType", "vegaSpec"]
+                    }
                   }
                 ]
               }
@@ -494,8 +542,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["options.chartType", "vegaSpec"],
-                "endpoint": "option-availability/dotplot"
+                "config": {
+                  "endpoint": "option-availability/dotplot",
+                  "fields": ["options.chartType", "vegaSpec"]
+                }
               }
             ]
           },
@@ -521,8 +571,10 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "fields": ["options.chartType", "vegaSpec"],
-                "endpoint": "option-availability/arrow"
+                "config": {
+                  "endpoint": "option-availability/arrow",
+                  "fields": ["options.chartType", "vegaSpec"]
+                }
               }
             ]
           },
@@ -543,12 +595,16 @@
                 "availabilityChecks": [
                   {
                     "type": "UserHasRole",
-                    "role": "expert-chart"
+                    "config": {
+                      "role": "expert-chart"
+                    }
                   },
                   {
                     "type": "ToolEndpoint",
-                    "fields": ["options.chartType", "vegaSpec"],
-                    "endpoint": "option-availability/arrow.colorScheme"
+                    "config": {
+                      "endpoint": "option-availability/arrow.colorScheme",
+                      "fields": ["options.chartType", "vegaSpec"]
+                    }
                   }
                 ]
               }
@@ -562,12 +618,16 @@
             "availabilityChecks": [
               {
                 "type": "UserHasRole",
-                "role": "expert-chart"
+                "config": {
+                  "role": "expert-chart"
+                }
               },
               {
                 "type": "ToolEndpoint",
-                "fields": ["vegaSpec", "options.chartType"],
-                "endpoint": "option-availability/colorOverwrite"
+                "config": {
+                  "endpoint": "option-availability/colorOverwrite",
+                  "fields": ["vegaSpec", "options.chartType"]
+                }
               }
             ],
             "compact": true,

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -147,7 +147,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["vegaSpec"],
                 "endpoint": "option-availability/chartType"
               }
             ],
@@ -199,7 +199,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["vegaSpec", "options.chartType"],
                 "endpoint": "option-availability/highlightDataSeries"
               }
             ]
@@ -213,7 +213,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["vegaSpec"],
                 "endpoint": "option-availability/hideAxisLabel"
               }
             ],
@@ -241,7 +241,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType"],
                     "endpoint": "option-availability/annotations.first"
                   }
                 ]
@@ -254,7 +254,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType"],
                     "endpoint": "option-availability/annotations.last"
                   }
                 ]
@@ -267,7 +267,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType"],
                     "endpoint": "option-availability/annotations.max"
                   }
                 ]
@@ -280,7 +280,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType"],
                     "endpoint": "option-availability/annotations.min"
                   }
                 ]
@@ -293,7 +293,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType"],
                     "endpoint": "option-availability/annotations.diff"
                   }
                 ]
@@ -304,7 +304,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["options.chartType", "vegaSpec", "data"],
                 "endpoint": "option-availability/annotations"
               }
             ]
@@ -317,7 +317,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/bar"
               }
             ]
@@ -357,7 +357,11 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": [
+                      "options.chartType",
+                      "options.barOptions.isBarChart",
+                      "vegaSpec"
+                    ],
                     "endpoint": "option-availability/forceBarsOnSmall"
                   }
                 ]
@@ -376,7 +380,13 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": [
+                  "data",
+                  "vegaSpec",
+                  "options.chartType",
+                  "options.barOptions.isBarChart",
+                  "options.barOptions.forceBarsOnSmall"
+                ],
                 "endpoint": "option-availability/dateseries"
               }
             ]
@@ -424,7 +434,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/line"
               }
             ]
@@ -465,7 +475,7 @@
                 "availabilityChecks": [
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["data", "options.chartType", "vegaSpec"],
                     "endpoint": "option-availability/line.isStockChart"
                   }
                 ]
@@ -481,7 +491,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/dotplot"
               }
             ]
@@ -508,7 +518,7 @@
             "availabilityChecks": [
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["options.chartType", "vegaSpec"],
                 "endpoint": "option-availability/arrow"
               }
             ]
@@ -534,7 +544,7 @@
                   },
                   {
                     "type": "ToolEndpoint",
-                    "withData": true,
+                    "data": ["options.chartType", "vegaSpec"],
                     "endpoint": "option-availability/arrow.colorScheme"
                   }
                 ]
@@ -553,7 +563,7 @@
               },
               {
                 "type": "ToolEndpoint",
-                "withData": true,
+                "data": ["vegaSpec", "options.chartType"],
                 "endpoint": "option-availability/colorOverwrite"
               }
             ],

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -154,8 +154,10 @@
             "selectType": "radio",
             "dynamicEnum": {
               "type": "ToolEndpoint",
-              "withData": true,
-              "endpoint": "dynamic-enum/chartType"
+              "config": {
+                "endpoint": "dynamic-enum/chartType",
+                "fields": ["data"]
+              }
             },
             "availabilityChecks": [
               {
@@ -212,8 +214,10 @@
           "Q:options": {
             "dynamicEnum": {
               "type": "ToolEndpoint",
-              "withData": true,
-              "endpoint": "dynamic-enum/highlightDataSeries"
+              "config": {
+                "endpoint": "dynamic-enum/highlightDataSeries",
+                "fields": ["data"]
+              }
             },
             "availabilityChecks": [
               {
@@ -465,8 +469,10 @@
               "Q:options": {
                 "dynamicEnum": {
                   "type": "ToolEndpoint",
-                  "withData": true,
-                  "endpoint": "dynamic-enum/prognosisStart"
+                  "config": {
+                    "endpoint": "dynamic-enum/prognosisStart",
+                    "fields": ["data"]
+                  }
                 }
               }
             }

--- a/routes/dynamic-enum.js
+++ b/routes/dynamic-enum.js
@@ -1,16 +1,17 @@
-const Boom = require('boom');
-const Joi = require('joi');
-const getFirstColumnSerie = require('../helpers/dateSeries.js').getFirstColumnSerie;
+const Boom = require("boom");
+const Joi = require("joi");
+const getFirstColumnSerie = require("../helpers/dateSeries.js")
+  .getFirstColumnSerie;
 
 function getChartTypeEnumWithTitles(item) {
   const chartTypes = {
     enum: ["Bar", "StackedBar", "Line", "Dotplot"],
     enum_titles: ["Säulen", "Gestapelte Säulen", "Linien", "Dot Plot"]
-  }
+  };
   try {
     if (item.data[0].length === 3) {
-      chartTypes.enum.push('Arrow');
-      chartTypes.enum_titles.push('Pfeile');
+      chartTypes.enum.push("Arrow");
+      chartTypes.enum_titles.push("Pfeile");
     }
   } catch (e) {
     // ignore the error, arrow will only be available if we have exactly 3 columns
@@ -28,30 +29,30 @@ function getHighlightEnum(item) {
 
 function getHighlightEnumTitles(item) {
   if (item.data.length < 1) {
-    return ['keine'];
+    return ["keine"];
   }
-  return ['keine'].concat(item.data[0].slice(1));
-} 
+  return ["keine"].concat(item.data[0].slice(1));
+}
 
 function getPrognosisStartEnum(item) {
   try {
     // constructs an array like [null,0,1,2,3,...] with the indexes from the first data column
     return [null].concat([...getFirstColumnSerie(item.data).keys()]);
   } catch (e) {
-    return [null]
+    return [null];
   }
 }
 function getPrognosisStartEnumTitles(item) {
   try {
-    return ['keine'].concat(getFirstColumnSerie(item.data));
+    return ["keine"].concat(getFirstColumnSerie(item.data));
   } catch (e) {
-    return ['keine']
+    return ["keine"];
   }
 }
 
 module.exports = {
-  method: 'POST',
-  path:'/dynamic-enum/{optionName}',
+  method: "POST",
+  path: "/dynamic-enum/{optionName}",
   options: {
     validate: {
       payload: Joi.object()
@@ -59,24 +60,25 @@ module.exports = {
     cors: true
   },
   handler: function(request, h) {
-    if (request.params.optionName === 'chartType') {
-      return getChartTypeEnumWithTitles(request.payload);
+    const item = request.payload.item;
+    if (request.params.optionName === "chartType") {
+      return getChartTypeEnumWithTitles(item);
     }
 
-    if (request.params.optionName === 'highlightDataSeries') {
+    if (request.params.optionName === "highlightDataSeries") {
       return {
-        enum: getHighlightEnum(request.payload),
-        enum_titles: getHighlightEnumTitles(request.payload)
+        enum: getHighlightEnum(item),
+        enum_titles: getHighlightEnumTitles(item)
       };
     }
 
-    if (request.params.optionName === 'prognosisStart') {
+    if (request.params.optionName === "prognosisStart") {
       return {
-        enum: getPrognosisStartEnum(request.payload),
-        enum_titles: getPrognosisStartEnumTitles(request.payload)
+        enum: getPrognosisStartEnum(item),
+        enum_titles: getPrognosisStartEnumTitles(item)
       };
     }
 
     return Boom.badRequest();
   }
-}
+};

--- a/routes/notification/hideAxisLabel.js
+++ b/routes/notification/hideAxisLabel.js
@@ -10,9 +10,7 @@ module.exports = {
       options: {
         allowUnknown: true
       },
-      payload: {
-        data: Joi.any().required()
-      }
+      payload: Joi.object().required()
     },
     cors: true,
     cache: {
@@ -22,9 +20,11 @@ module.exports = {
   },
   handler: function(request, h) {
     try {
-      const data = request.payload.data[0];
-      const hideAxisLabel = request.payload.data[1];
-      if (!hideAxisLabel && dateSeries.isDateSeriesData(data)) {
+      const item = request.payload.item;
+      if (
+        !item.options.hideAxisLabel &&
+        dateSeries.isDateSeriesData(item.data)
+      ) {
         return {
           message: {
             title: "notifications.hideAxisLabel.title",

--- a/routes/notification/shouldBeBarChart.js
+++ b/routes/notification/shouldBeBarChart.js
@@ -9,21 +9,18 @@ module.exports = {
       options: {
         allowUnknown: true
       },
-      payload: {
-        data: Joi.array().required(),
-        options: Joi.object().required()
-      }
+      payload: Joi.object().required()
     },
     cors: true,
     tags: ["api"]
   },
   handler: function(request, h) {
     try {
-      const data = request.payload.data[0];
-      const chartType = request.payload.data[1];
+      const item = request.payload.item;
+      const options = request.payload.options;
       if (
-        chartType === "StackedBar" &&
-        data[0].length === request.payload.options.limit
+        item.options.chartType === "StackedBar" &&
+        item.data[0].length === options.limit
       ) {
         return {
           message: {

--- a/routes/notification/shouldBeBars.js
+++ b/routes/notification/shouldBeBars.js
@@ -10,28 +10,22 @@ module.exports = {
       options: {
         allowUnknown: true
       },
-      payload: {
-        data: Joi.array().required(),
-        options: Joi.object().required()
-      }
+      payload: Joi.object().required()
     },
     cors: true,
     tags: ["api"]
   },
   handler: function(request, h) {
     try {
-      const data = request.payload.data[0];
-      const chartType = request.payload.data[1];
-      const isBarChart = request.payload.data[2];
-      const forceBarsOnSmall = request.payload.data[3];
-
+      const item = request.payload.item;
+      const options = request.payload.options;
       if (
-        data[0] &&
-        ["Bar", "StackedBar"].includes(chartType) &&
-        !isBarChart &&
-        !forceBarsOnSmall &&
-        data[0].length > request.payload.options.limit &&
-        !dateSeries.isDateSeriesData(data)
+        item.data[0] &&
+        ["Bar", "StackedBar"].includes(item.options.chartType) &&
+        !item.options.barOptions.isBarChart &&
+        !item.options.barOptions.forceBarsOnSmall &&
+        item.data[0].length > options.limit &&
+        !dateSeries.isDateSeriesData(item.data)
       ) {
         return {
           message: {

--- a/routes/notification/shouldBeLineChart.js
+++ b/routes/notification/shouldBeLineChart.js
@@ -11,24 +11,21 @@ module.exports = {
       options: {
         allowUnknown: true
       },
-      payload: {
-        data: Joi.array().required(),
-        options: Joi.object().required()
-      }
+      payload: Joi.object().required()
     },
     cors: true,
     tags: ["api"]
   },
   handler: function(request, h) {
     try {
-      const data = request.payload.data[0];
-      const chartType = request.payload.data[1];
-      const amountOfRows = array2d.height(data);
+      const item = request.payload.item;
+      const options = request.payload.options;
+      const amountOfRows = array2d.height(item.data);
       if (
-        chartType !== "Line" &&
-        data[0] &&
-        amountOfRows > request.payload.options.limit &&
-        dateSeries.isDateSeriesData(data)
+        item.options.chartType !== "Line" &&
+        item.data[0] &&
+        amountOfRows > options.limit &&
+        dateSeries.isDateSeriesData(item.data)
       ) {
         return {
           message: {

--- a/routes/notification/unsupportedDateFormat.js
+++ b/routes/notification/unsupportedDateFormat.js
@@ -11,24 +11,22 @@ module.exports = {
       options: {
         allowUnknown: true
       },
-      payload: {
-        data: Joi.array().required()
-      }
+      payload: Joi.object().required()
     },
     cors: true,
     tags: ["api"]
   },
   handler: function(request, h) {
     try {
-      const data = request.payload.data[0];
+      const item = request.payload.item;
       // if this is a correct date series, we do not have a problem
-      if (helpers.isDateSeriesData(data)) {
+      if (helpers.isDateSeriesData(item.data)) {
         return null;
       }
 
       // a wrong date format is detected by strings with two dots or slashes or dashes separating numbers
       for (let separator of separators) {
-        for (let row of data.slice(1)) {
+        for (let row of item.data.slice(1)) {
           let parts = row[0].split(separator);
           if (
             parts.length === 3 &&

--- a/routes/option-availability.js
+++ b/routes/option-availability.js
@@ -40,37 +40,36 @@ module.exports = {
     cors: true
   },
   handler: function(request, h) {
+    const item = request.payload.item;
     if (request.params.optionName === "bar") {
       return {
-        available:
-          isBarChart(request.payload) && hasNoCustomVegaSpec(request.payload)
+        available: isBarChart(item) && hasNoCustomVegaSpec(item)
       };
     }
 
     if (request.params.optionName === "forceBarsOnSmall") {
       return {
         available:
-          isBarChart(request.payload) &&
-          !request.payload.options.barOptions.isBarChart &&
-          hasNoCustomVegaSpec(request.payload)
+          isBarChart(item) &&
+          !item.options.barOptions.isBarChart &&
+          hasNoCustomVegaSpec(item)
       };
     }
 
     if (request.params.optionName === "line") {
       return {
-        available:
-          isLineChart(request.payload) && hasNoCustomVegaSpec(request.payload)
+        available: isLineChart(item) && hasNoCustomVegaSpec(item)
       };
     }
 
     if (request.params.optionName === "line.isStockChart") {
       try {
-        const serie = getFirstColumnSerie(request.payload.data);
+        const serie = getFirstColumnSerie(item.data);
         return {
           available:
             isDateSeries(serie) &&
-            isLineChart(request.payload) &&
-            hasNoCustomVegaSpec(request.payload)
+            isLineChart(item) &&
+            hasNoCustomVegaSpec(item)
         };
       } catch (e) {
         return {
@@ -81,23 +80,21 @@ module.exports = {
 
     if (request.params.optionName === "dotplot") {
       return {
-        available:
-          isDotplot(request.payload) && hasNoCustomVegaSpec(request.payload)
+        available: isDotplot(item) && hasNoCustomVegaSpec(item)
       };
     }
 
     if (request.params.optionName === "arrow") {
       return {
-        available:
-          isArrowChart(request.payload) && hasNoCustomVegaSpec(request.payload)
+        available: isArrowChart(item) && hasNoCustomVegaSpec(item)
       };
     }
 
     if (request.params.optionName === "arrow.colorScheme") {
       return {
         available:
-          isArrowChart(request.payload) &&
-          hasNoCustomVegaSpec(request.payload) &&
+          isArrowChart(item) &&
+          hasNoCustomVegaSpec(item) &&
           configuredDivergingColorSchemes
       };
     }
@@ -105,7 +102,7 @@ module.exports = {
     if (request.params.optionName === "dateseries") {
       // check first if the chart type actually supports date series handling
       // first we need to know if there is a chartType and which one
-      const chartType = getChartTypeForItemAndWidth(request.payload, 400); // just hardcode a small width here
+      const chartType = getChartTypeForItemAndWidth(item, 400); // just hardcode a small width here
 
       const chartTypeConfig = require(`../chartTypes/${chartType}/config.js`);
       if (!chartTypeConfig.data.handleDateSeries) {
@@ -117,9 +114,8 @@ module.exports = {
       let isAvailable;
 
       try {
-        const serie = getFirstColumnSerie(request.payload.data);
-        isAvailable =
-          isDateSeries(serie) && hasNoCustomVegaSpec(request.payload);
+        const serie = getFirstColumnSerie(item.data);
+        isAvailable = isDateSeries(serie) && hasNoCustomVegaSpec(item);
       } catch (e) {
         isAvailable = false;
       }
@@ -134,7 +130,7 @@ module.exports = {
       request.params.optionName === "hideAxisLabel"
     ) {
       return {
-        available: hasNoCustomVegaSpec(request.payload)
+        available: hasNoCustomVegaSpec(item)
       };
     }
 
@@ -143,29 +139,25 @@ module.exports = {
       request.params.optionName === "colorOverwrite"
     ) {
       return {
-        available:
-          hasNoCustomVegaSpec(request.payload) && !isArrowChart(request.payload)
+        available: hasNoCustomVegaSpec(item) && !isArrowChart(item)
       };
     }
 
     if (request.params.optionName === "annotations") {
       let available = false;
       if (
-        isLineChart(request.payload) &&
-        hasNoCustomVegaSpec(request.payload) &&
-        request.payload.data[0].length === 2 // only if there is just one data series
+        isLineChart(item) &&
+        hasNoCustomVegaSpec(item) &&
+        item.data[0].length === 2 // only if there is just one data series
       ) {
         available = true;
       }
 
-      if (isDotplot(request.payload) && hasNoCustomVegaSpec(request.payload)) {
+      if (isDotplot(item) && hasNoCustomVegaSpec(item)) {
         available = true;
       }
 
-      if (
-        isArrowChart(request.payload) &&
-        hasNoCustomVegaSpec(request.payload)
-      ) {
+      if (isArrowChart(item) && hasNoCustomVegaSpec(item)) {
         available = true;
       }
 
@@ -176,40 +168,39 @@ module.exports = {
 
     if (request.params.optionName === "annotations.first") {
       return {
-        available: isLineChart(request.payload) || isArrowChart(request.payload)
+        available: isLineChart(item) || isArrowChart(item)
       };
     }
 
     if (request.params.optionName === "annotations.last") {
       return {
-        available: isLineChart(request.payload) || isArrowChart(request.payload)
+        available: isLineChart(item) || isArrowChart(item)
       };
     }
 
     if (request.params.optionName === "annotations.max") {
       return {
-        available: isLineChart(request.payload) || isDotplot(request.payload)
+        available: isLineChart(item) || isDotplot(item)
       };
     }
 
     if (request.params.optionName === "annotations.min") {
       return {
-        available: isLineChart(request.payload) || isDotplot(request.payload)
+        available: isLineChart(item) || isDotplot(item)
       };
     }
 
     if (request.params.optionName === "annotations.diff") {
       return {
-        available: isDotplot(request.payload) || isArrowChart(request.payload)
+        available: isDotplot(item) || isArrowChart(item)
       };
     }
 
     if (request.params.optionName === "displayWeight") {
       return {
         available:
-          isLineChart(request.payload) ||
-          (isBarChart(request.payload) &&
-            !request.payload.options.barOptions.isBarChart)
+          isLineChart(item) ||
+          (isBarChart(item) && !item.options.barOptions.isBarChart)
       };
     }
 

--- a/routes/option-availability.js
+++ b/routes/option-availability.js
@@ -140,7 +140,6 @@ module.exports = {
 
     if (
       request.params.optionName === "highlightDataSeries" ||
-      request.params.optionName === "highlightDataSeries" ||
       request.params.optionName === "colorOverwrite"
     ) {
       return {
@@ -206,13 +205,11 @@ module.exports = {
     }
 
     if (request.params.optionName === "displayWeight") {
-      const options = request.payload.options;
       return {
         available:
           isLineChart(request.payload) ||
-          ((options.chartType === "Bar" ||
-            options.chartType === "StackedBar") &&
-            options.barOptions.isBarChart === false)
+          (isBarChart(request.payload) &&
+            !request.payload.options.barOptions.isBarChart)
       };
     }
 


### PR DESCRIPTION
- This PR adjusts the schema of availability-checks, notification-checks and dynamic-enums
- All the properties specific to a check live now in the config object. The properties specific to the type of check (`priority`) live next to the type property:

```json
{
  "type": "ToolEndpoint",
  "config": {
    "endpoint": "notification/unsupportedDateFormat",
    "fields": ["data"],
    "options": {
      "limit": 8
    }
  },
  "priority": {
    "type": "medium",
    "value": 3
  }
}
```
- All the checks now make use of the `fields` property to define which parts of the item are needed for the check
- The ToolEndpoint receives now an object containing the `item` and an optional `options` object (the corresponding routes (notifications, option-availability and dynamic-enums) where updated to reflect this change) 
- This branch will be deployed on test as soon as https://github.com/nzzdev/Q-chart/pull/110 is merged