### PR TITLE
Feat hide label if one bar

### DIFF
--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -183,6 +183,15 @@ module.exports = function getMapping() {
         objectPath.set(spec, "scales.0.nice", false);
         objectPath.set(spec, "scales.0.domainMax", maxValue / divisor);
       }
+    },
+    {
+      path: "item.data",
+      mapToSpec: function(data, spec, mappingData) {
+        // if we will only display one single bar, we should not show the Y axis label
+        if (data.length === 2) {
+          objectPath.set(spec, "axes.1.labels", false);
+        }
+      }
     }
   ]
     .concat(commonMappings.getBarDateSeriesHandlingMappings())

--- a/resources/fixtures/data/bar-stacked-100.json
+++ b/resources/fixtures/data/bar-stacked-100.json
@@ -15,7 +15,7 @@
   ],
   "options": {
     "chartType": "StackedBar",
-    "hideAxisLabel": false,
+    "hideAxisLabel": true,
     "barOptions": {
       "isBarChart": false,
       "forceBarsOnSmall": true


### PR DESCRIPTION
- implements #98 
- deployed on test
- can be tested using fixture item `chart-10` on test env
- other bar charts should still show the labels on the Y axis