### PR TITLE
Release 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/routes/dynamic-schema.js
+++ b/routes/dynamic-schema.js
@@ -81,10 +81,14 @@ module.exports = {
     if (request.params.optionName === "colorOverwritesRowsItem") {
       try {
         return {
-          enum: [null].concat(item.data.map((row, index) => index + 1)),
+          enum: [null].concat(
+            item.data.slice(1).map((row, index) => index + 1)
+          ),
           "Q:options": {
             enum_titles: [""].concat(
-              item.data.map((row, index) => `${index + 1} - (${row[0]})`)
+              item.data
+                .slice(1)
+                .map((row, index) => `${index + 1} - (${row[0]})`)
             )
           }
         };


### PR DESCRIPTION
- Fixes a bug where the enum for `colorOverwritesRows` included the header row as well
- The logic for the overwrite index number can stay the same (as to achieve the correct overwrite, one had to select the wrong line)