### PR TITLE
(dots) fix highlighting rows 

### DIFF
--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -172,7 +172,7 @@ module.exports = function getMapping() {
     },
     {
       path: "item.options.dotplotOptions.connectDots",
-      mapToSpec: function(connectDots, spec) {
+      mapToSpec: function(connectDots, spec, mappingData) {
         if (!connectDots) {
           return;
         }
@@ -192,12 +192,24 @@ module.exports = function getMapping() {
                 field: "yValue"
               },
               strokeMiterLimit: 0,
-              stroke: {
-                value: spec.config.axis.labelColor
-              },
               strokeWidth: {
                 value: 2
-              }
+              },
+              stroke: [
+                {
+                  test: "datum.isHighlighted === true",
+                  value: spec.config.axis.labelColor
+                },
+                {
+                  test: "datum.isHighlighted === false",
+                  value:
+                    spec.config.axis.labelColorLight ||
+                    spec.config.axis.labelColor
+                },
+                {
+                  value: spec.config.axis.labelColor
+                }
+              ]
             }
           }
         };
@@ -230,7 +242,21 @@ module.exports = function getMapping() {
               x: {
                 signal: "scale('xScale', datum.yValue) - 8"
               },
-              fill: { value: spec.config.axis.labelColor },
+              fill: [
+                {
+                  test: "datum.isHighlighted === true",
+                  value: spec.config.axis.labelColor
+                },
+                {
+                  test: "datum.isHighlighted === false",
+                  value:
+                    spec.config.axis.labelColorLight ||
+                    spec.config.axis.labelColor
+                },
+                {
+                  value: spec.config.axis.labelColor
+                }
+              ],
               align: { value: "right" },
               baseline: { value: "middle" },
               fontSize: { value: spec.config.text.fontSize + 2 }
@@ -266,7 +292,21 @@ module.exports = function getMapping() {
               x: {
                 signal: "scale('xScale', datum.yValue) + 8"
               },
-              fill: { value: spec.config.axis.labelColor },
+              fill: [
+                {
+                  test: "datum.isHighlighted === true",
+                  value: spec.config.axis.labelColor
+                },
+                {
+                  test: "datum.isHighlighted === false",
+                  value:
+                    spec.config.axis.labelColorLight ||
+                    spec.config.axis.labelColor
+                },
+                {
+                  value: spec.config.axis.labelColor
+                }
+              ],
               align: { value: "left" },
               baseline: { value: "middle" },
               fontSize: { value: spec.config.text.fontSize + 2 }
@@ -320,7 +360,21 @@ module.exports = function getMapping() {
                 scale: "xScale",
                 signal: "datum.yValue - (datum.diffToPrevious / 2)"
               },
-              fill: { value: spec.config.axis.labelColor },
+              fill: [
+                {
+                  test: "datum.isHighlighted === true",
+                  value: spec.config.axis.labelColor
+                },
+                {
+                  test: "datum.isHighlighted === false",
+                  value:
+                    spec.config.axis.labelColorLight ||
+                    spec.config.axis.labelColor
+                },
+                {
+                  value: spec.config.axis.labelColor
+                }
+              ],
               align: { value: "center" },
               baseline: { value: "bottom" },
               fontSize: { value: spec.config.text.fontSize + 2 }

--- a/cli-config.js
+++ b/cli-config.js
@@ -29,9 +29,7 @@ async function loadSophieModules(target) {
 
   const moduleString = Object.keys(sophieModules)
     .map(moduleKey => {
-      return `${sophieModules[moduleKey].name}@${
-        sophieModules[moduleKey].version
-      }`;
+      return `${sophieModules[moduleKey].name}@${sophieModules[moduleKey].version}`;
     })
     .join(",");
 
@@ -127,6 +125,7 @@ async function getAxisConfig(target) {
     domainColor: sophieColorVars.general["s-color-gray-3"],
     tickColor: sophieColorVars.general["s-color-gray-3"],
     labelFont: fontFamilyPerTarget[target],
+    labelColorLight: sophieColorVars.general["s-color-gray-5"],
     labelColor: sophieColorVars.general["s-color-gray-7"],
     labelColorDark: sophieColorVars.general["s-color-gray-9"],
     labelFontSize: 11,

--- a/resources/fixtures/data/dotplot-floating-point.json
+++ b/resources/fixtures/data/dotplot-floating-point.json
@@ -61,6 +61,7 @@
       "connectDots": true
     },
     "highlightDataSeries": [],
+    "highlightDataRows": [2],
     "colorOverwritesSeries": []
   }
 }


### PR DESCRIPTION
- uses `config.axis.labelColorLight` for not-highlighted connect-dot-lines and annotations if given, falls back to `config.axis.labelColor` for backwards compatibility