### PR TITLE
Release 3.1.1

### DIFF
--- a/chartTypes/area/mapping.js
+++ b/chartTypes/area/mapping.js
@@ -37,8 +37,12 @@ module.exports = function getMappings() {
     },
     {
       path: "item.options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+      mapToSpec: function(hideAxisLabel, spec, mappingData) {
+        if (
+          hideAxisLabel === true ||
+          (typeof objectPath.get(spec, "axes.0.title") !== "string" ||
+            objectPath.get(spec, "axes.0.title").length < 1)
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
           objectPath.set(spec, "height", spec.height - 20); // decrease the height because we do not need space for the axis title

--- a/chartTypes/arrow/mapping.js
+++ b/chartTypes/arrow/mapping.js
@@ -125,7 +125,10 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          objectPath.get(spec, "axes.1.title").length < 1
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
           objectPath.set(spec, "height", spec.height - 30); // decrease the height because we do not need space for the axis title

--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -9,7 +9,7 @@ const commonMappings = require("../commonMappings.js");
 
 const getLongestDataLabel = require("../../helpers/data.js")
   .getLongestDataLabel;
-const textMetrics = require("vega").textMetrics;
+const textMeasure = require("../../helpers/textMeasure.js");
 
 function shouldHaveLabelsOnTopOfBar(mappingData) {
   const item = mappingData.item;
@@ -21,10 +21,10 @@ function shouldHaveLabelsOnTopOfBar(mappingData) {
   }
 
   const longestLabel = getLongestDataLabel(mappingData, true);
-  const textItem = {
-    text: longestLabel
-  };
-  const longestLabelWidth = textMetrics.width(textItem);
+  const longestLabelWidth = textMeasure.getLabelTextWidth(
+    longestLabel,
+    mappingData.toolRuntimeConfig
+  );
 
   if (mappingData.width / 3 < longestLabelWidth) {
     return true;
@@ -175,7 +175,10 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          objectPath.get(spec, "axes.1.title").length < 1
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
           objectPath.set(spec, "height", spec.height - 30); // decrease the height because we do not need space for the axis title

--- a/chartTypes/bar/mapping.js
+++ b/chartTypes/bar/mapping.js
@@ -323,7 +323,10 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          objectPath.get(spec, "axes.1.title").length < 1
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
           objectPath.set(spec, "height", spec.height - 30); // decrease the height because we do not need space for the axis title

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -79,7 +79,11 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          (typeof objectPath.get(spec, "axes.0.title") !== "string" ||
+            objectPath.get(spec, "axes.0.title").length < 1)
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
           objectPath.set(spec, "height", spec.height - 20); // decrease the height because we do not need space for the axis title

--- a/chartTypes/column-stacked/vega-spec.json
+++ b/chartTypes/column-stacked/vega-spec.json
@@ -189,11 +189,6 @@
       "padding": 0.4,
       "zero": true,
       "grid": true,
-      "gridColor": "#e9e9ee",
-      "labelAngle": 0,
-      "labelBound": false,
-      "labelFlush": false,
-      "labelFlushOffset": false,
       "ticks": true
     }
   }

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -56,7 +56,11 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          (typeof objectPath.get(spec, "axes.0.title") !== "string" ||
+            objectPath.get(spec, "axes.0.title").length < 1)
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
           objectPath.set(spec, "height", spec.height - 20); // decrease the height because we do not need space for the axis title

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -121,6 +121,7 @@ function getColumnDateSeriesHandlingMappings() {
           objectPath.set(spec, "axes.0.encode.labels.update.text", {
             signal: `formatDateForInterval(datum.value, '${interval}')`
           });
+          objectPath.set(spec, "axes.0.labelBound", true);
           objectPath.set(spec, "axes.0.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
         }
       }
@@ -137,6 +138,7 @@ function getBarDateSeriesHandlingMappings() {
           objectPath.set(spec, "axes.1.encode.labels.update.text", {
             signal: `formatDateForInterval(datum.value, '${interval}')`
           });
+          objectPath.set(spec, "axes.1.labelBound", true);
           objectPath.set(spec, "axes.1.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
         }
       }
@@ -297,12 +299,16 @@ function getHeightMappings() {
         }
         let height = spec.width * aspectRatio;
 
-        // minimum height is 240px
+        // minimum height is 240px, chart grid never gets portrait mode but a square or a wide format
         if (height < Math.min(240, spec.width)) {
           height = Math.min(240, spec.width);
         }
-        // increase the height if hideAxisLabel option is unchecked
-        if (mappingData.item.options.hideAxisLabel === false) {
+        // increase the height if hideAxisLabel option is unchecked and there actually is a title
+        if (
+          mappingData.item.options.hideAxisLabel === false &&
+          typeof mappingData.item.data[0][0] === "string" &&
+          mappingData.item.data[0][0].length > 0 // check the data instead of the spec here because we don't know if this is the x or y axis
+        ) {
           height = height + 20;
         }
         objectPath.set(spec, "height", height);

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -133,7 +133,10 @@ module.exports = function getMapping() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          objectPath.get(spec, "axes.1.title").length < 1
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.1.title", undefined);
           objectPath.set(spec, "height", spec.height - 30); // decrease the height because we do not need space for the axis title

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -161,7 +161,11 @@ module.exports = function getMappings() {
     {
       path: "item.options.hideAxisLabel",
       mapToSpec: function(hideAxisLabel, spec) {
-        if (hideAxisLabel === true) {
+        if (
+          hideAxisLabel === true ||
+          (typeof objectPath.get(spec, "axes.0.title") !== "string" ||
+            objectPath.get(spec, "axes.0.title").length < 1)
+        ) {
           // unset the x axis label
           objectPath.set(spec, "axes.0.title", undefined);
           objectPath.set(spec, "height", spec.height - 20); // decrease the height because we do not need space for the axis title

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -237,12 +237,12 @@ module.exports = function getMappings() {
         const lineMark = clone(spec.marks[0].marks[0]);
         lineMark.encode.enter.defined = {
           signal:
-            "datum.xValue !== null && timeFormat(datum.xValue, '%Q') <= timeFormat(prognosisStartDate, '%Q')"
+            "datum.yValue !== null && timeFormat(datum.xValue, '%Q') <= timeFormat(prognosisStartDate, '%Q')"
         };
         const lineMarkPrognosis = clone(spec.marks[0].marks[0]);
         lineMarkPrognosis.encode.enter.defined = {
           signal:
-            "datum.xValue !== null && timeFormat(datum.xValue, '%Q') >= timeFormat(prognosisStartDate, '%Q')"
+            "datum.yValue !== null && timeFormat(datum.xValue, '%Q') >= timeFormat(prognosisStartDate, '%Q')"
         };
         lineMarkPrognosis.style = "prognosisLine";
         spec.marks[0].marks = [lineMark, lineMarkPrognosis];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- fix: line charts with missing values (null) and prognosis render correctly
- fix: if no axis title is given (empty cell) no space is reserved for the title
- some other small fixes