### PR TITLE
(bar/line/area) Fix prognosisStartDate comparison expressions

### DIFF
--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -173,8 +173,7 @@ function getColumnAreaPrognosisMappings() {
           transform: [
             {
               type: "filter",
-              expr:
-                "timeFormat(datum.xValue, '%Q') >= timeFormat(prognosisStartDate, '%Q')"
+              expr: "datum.xValue >= prognosisStartDate"
             }
           ]
         });
@@ -226,8 +225,7 @@ function getBarPrognosisMappings() {
           transform: [
             {
               type: "filter",
-              expr:
-                "timeFormat(datum.xValue, '%Q') >= timeFormat(prognosisStartDate, '%Q')"
+              expr: "datum.xValue >= prognosisStartDate"
             }
           ]
         });

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -240,13 +240,11 @@ module.exports = function getMappings() {
         // split the marks at the prognosisStart index
         const lineMark = clone(spec.marks[0].marks[0]);
         lineMark.encode.enter.defined = {
-          signal:
-            "datum.yValue !== null && timeFormat(datum.xValue, '%Q') <= timeFormat(prognosisStartDate, '%Q')"
+          signal: "datum.yValue !== null && datum.xValue <= prognosisStartDate"
         };
         const lineMarkPrognosis = clone(spec.marks[0].marks[0]);
         lineMarkPrognosis.encode.enter.defined = {
-          signal:
-            "datum.yValue !== null && timeFormat(datum.xValue, '%Q') >= timeFormat(prognosisStartDate, '%Q')"
+          signal: "datum.yValue !== null && datum.xValue >= prognosisStartDate"
         };
         lineMarkPrognosis.style = "prognosisLine";
         spec.marks[0].marks = [lineMark, lineMarkPrognosis];


### PR DESCRIPTION
Use timestamps directly instead of using timeFormat with `%Q`.

`timeFormat` returns a string, which would lead to wrong comparisons for timestamps before/after 9 September 2001 (Unix time 1000000000, dates before have Unix time starting with 9, which makes them "greater" for string comparison, e.g. "999" > "1000" is true)

See https://3.basecamp.com/3500782/buckets/1333707/todos/2164074609

Before:

![image](https://user-images.githubusercontent.com/47303530/67956661-c0fe6400-fbf4-11e9-9e48-5c8bf31f38ca.png)

After:

![image](https://user-images.githubusercontent.com/47303530/67957331-b6909a00-fbf5-11e9-9470-75fd51d31a80.png)
