### PR TITLE
Add some paddingOuter to column charts

### DIFF
--- a/chartTypes/column-stacked/vega-spec.json
+++ b/chartTypes/column-stacked/vega-spec.json
@@ -50,6 +50,7 @@
         "field": "xValue"
       },
       "padding": 0,
+      "paddingOuter": 0.2,
       "round": true
     },
     {

--- a/chartTypes/column/vega-spec.json
+++ b/chartTypes/column/vega-spec.json
@@ -31,6 +31,7 @@
         "field": "xValue"
       },
       "padding": 0,
+      "paddingOuter": 0.2,
       "round": true
     },
     {


### PR DESCRIPTION
This gives some more space to the first and last label.

Fixes [this issue](https://3.basecamp.com/3500782/buckets/1333707/todos/2233603449).