### PR TITLE
Fix adding events to existing charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -965,11 +965,13 @@
         },
         "date": {
           "title": "Zeitpunkt",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "label": {
           "title": "Annotation",
-          "type": "string"
+          "type": "string",
+          "default": ""
         }
       },
       "required": ["date", "label"]
@@ -988,15 +990,18 @@
         },
         "dateFrom": {
           "title": "Von",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "dateTo": {
           "title": "Bis",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "label": {
           "title": "Annotation",
-          "type": "string"
+          "type": "string",
+          "default": ""
         }
       },
       "required": ["dateFrom", "dateTo", "label"]

--- a/routes/notification/unsupportedDateFormatEvents.js
+++ b/routes/notification/unsupportedDateFormatEvents.js
@@ -27,7 +27,7 @@ module.exports = {
           eventDates.push(event.dateFrom, event.dateTo);
         }
         for (let eventDate of eventDates) {
-          if (!helpers.getDateFormatForValue(eventDate)) {
+          if (eventDate && !helpers.getDateFormatForValue(eventDate)) {
             return {
               message: {
                 title: "notifications.unsupportedDateFormatEvents.title",


### PR DESCRIPTION
- Set an empty string default value for all required field of event-point and event-range.
- Do not show unsupported date format warning if date field is empty.

The first change fixes [a bug](https://3.basecamp.com/3500782/buckets/1333707/todos/2411966118) where it was not possible to add event / time span annotations for existing charts.

If required fields do not have a default value, they are "undefined", and so a newly created event does not validate against the event-point or event-range schema.

Relevant code in Q-Editor:
https://github.com/nzzdev/Q-editor/blob/9ed126b2a9ca1fee214130c902c957f02f1ec79f/client/src/elements/schema-editor/schema-editor-array.js#L264-L273


Deployed on staging, test example here:
https://q.st-staging.nzz.ch/item/6dcf203a5c5f74b61aeea0cb0ee5d4e6