### PR TITLE
Release 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 
 RUN apt-get update && apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-# Copy package.json into work directory and install dependencies
-# We do not copy package-lock.json here as we do want the specific binary stuff (canvas) for the specific plattform of the docker container
+# Copy package.json and package-lock.json into work directory and install dependencies
 COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
 RUN npm install --production
 
 # Copy everthing else in work directory

--- a/chartTypes/commonPostprocessings.js
+++ b/chartTypes/commonPostprocessings.js
@@ -170,23 +170,7 @@ const highlightZeroGridLineIfPositiveAndNegative = {
         .querySelector(".role-axis-grid")
         .querySelectorAll("line");
 
-      const yAxisTicklines = axisElements
-        .item(axisIndex)
-        .querySelector(".role-axis-tick")
-        .querySelectorAll("line");
-
       yAxisGridlines.item(zeroTickIndex).setAttribute(
-        "style",
-        yAxisGridlines
-          .item(zeroTickIndex)
-          .getAttribute("style")
-          .replace(
-            `stroke: ${toolRuntimeConfig.axis.tickColor}`,
-            `stroke: ${toolRuntimeConfig.axis.labelColor}`
-          )
-      );
-
-      yAxisTicklines.item(zeroTickIndex).setAttribute(
         "style",
         yAxisGridlines
           .item(zeroTickIndex)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Bug fix

Fix bug in `highlightZeroGridLineIfPositiveAndNegative` postprocessing by removing highlighting of tick lines which do not exist anymore.

The following was happening before:
- For charts with positive and negative values, the code to highlight the zero line was called
- An exception was thrown for the access to the result of querySelector(".role-axis-tick") that
  returned null (because there are no y axis ticks).
- The exception was caught, but all postprocessings afterwards were not carried out
  - for line charts: highlight zero line, outlines for annotation labels, reverse line order
  - for area charts: highlight zero line
  => these are now working again

Bug introduced in 5ee98b6 when the y axis ticks were removed.

See also
- [Discussion about outlines for annotation labels on Basecamp](https://3.basecamp.com/3500782/buckets/1333708/todos/1047998400)

## Pin dependency versions

Use `package-lock.json` in `Dockerfile`

This makes sure that we are installing the same versions of dependencies as when testing locally,
and prevents several bugs that would appear with the latest (v5.15.0) version of vega.

There was a comment why this was not done before:

> We do not copy package-lock.json here as we do want the specific
> binary stuff (canvas) for the specific plattform of the docker container

but as far as I understand (and tested), the "canvas" dependency works perfectly fine inside
the docker container, even if `package-lock.json` was created on macOS. Even with the same
version number, different binaries will be installed depending on the OS.

## Comparison before / after

Bug before this release (zero line highlight and outlines for annotation labels are missing):

![Screenshot 2020-09-04 at 18 00 46](https://user-images.githubusercontent.com/47303530/92262762-e24a7380-eedb-11ea-9077-7c4a12c2a2a1.png)

---

With fix from this release:

![Screenshot 2020-09-04 at 18 01 17](https://user-images.githubusercontent.com/47303530/92262801-ef676280-eedb-11ea-9cd9-5f7b11a3d96a.png)

---

With 5ee98b6 reverted (before Oct 17 2019):

![Screenshot 2020-09-04 at 18 00 26](https://user-images.githubusercontent.com/47303530/92262593-add6b780-eedb-11ea-833c-0ff8ba2f73aa.png)
