### PR TITLE
Release 3.2.5

### DIFF
--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -3,20 +3,21 @@ const objectPath = require("object-path");
 const intervals = require("../../helpers/dateSeries.js").intervals;
 const dateSeries = require("../../helpers/dateSeries.js");
 const dataHelpers = require("../../helpers/data.js");
+const { convertDateObjectsToTimestamps } = require("../../helpers/events.js");
 
 const commonMappings = require("../commonMappings.js");
 
 const annotation = require("./annotation.js");
 
 const d3 = {
-  array: require("d3-array")
+  array: require("d3-array"),
 };
 
 module.exports = function getMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function (itemData, spec) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
@@ -40,18 +41,18 @@ module.exports = function getMappings() {
                     xValue: x,
                     xIndex: rowIndex,
                     yValue: value,
-                    cValue: index
+                    cValue: index,
                   };
                 });
               })
-              .flat()
-          }
+              .flat(),
+          },
         ];
-      }
+      },
     },
     {
       path: "item.options.annotations",
-      mapToSpec: function(annotationOptions, spec, mappingData) {
+      mapToSpec: function (annotationOptions, spec, mappingData) {
         const item = mappingData.item;
         // this option is only available if we have exactly one data series
         if (item.data[0].length !== 2) {
@@ -81,7 +82,7 @@ module.exports = function getMappings() {
               firstValue.yValue > secondValue.yValue &&
               !item.options.lineChartOptions.reverseYScale
                 ? "top"
-                : "bottom"
+                : "bottom",
           },
           {
             optionName: "last",
@@ -92,7 +93,7 @@ module.exports = function getMappings() {
               lastValue.yValue > secondLastValue.yValue &&
               !item.options.lineChartOptions.reverseYScale
                 ? "top"
-                : "bottom"
+                : "bottom",
           },
           {
             optionName: "max",
@@ -106,7 +107,7 @@ module.exports = function getMappings() {
                 : "center",
             verticalAlign: !item.options.lineChartOptions.reverseYScale
               ? "top"
-              : "bottom"
+              : "bottom",
           },
           {
             optionName: "min",
@@ -120,16 +121,16 @@ module.exports = function getMappings() {
                 : "center",
             verticalAlign: !item.options.lineChartOptions.reverseYScale
               ? "bottom"
-              : "top"
-          }
+              : "top",
+          },
         ]
-          .filter(annotation => {
+          .filter((annotation) => {
             return annotationOptions[annotation.optionName] === true;
           })
           .reduce((annotations, testAnnotation) => {
             // make the annotations unique by xValue
             if (
-              !annotations.find(annotation => {
+              !annotations.find((annotation) => {
                 return (
                   testAnnotation.value.xValue.toString() ===
                   annotation.value.xValue.toString()
@@ -144,7 +145,7 @@ module.exports = function getMappings() {
         for (const valueToAnnotate of valuesToAnnotate) {
           objectPath.push(spec, "data", {
             name: valueToAnnotate.dataName,
-            values: [valueToAnnotate.value]
+            values: [valueToAnnotate.value],
           });
 
           const symbol = annotation.getSymbol(valueToAnnotate.dataName);
@@ -156,11 +157,11 @@ module.exports = function getMappings() {
           objectPath.push(spec, "marks", symbol);
           objectPath.push(spec, "marks", label);
         }
-      }
+      },
     },
     {
       path: "item.options.hideAxisLabel",
-      mapToSpec: function(hideAxisLabel, spec) {
+      mapToSpec: function (hideAxisLabel, spec) {
         if (
           hideAxisLabel === true ||
           typeof objectPath.get(spec, "axes.0.title") !== "string" ||
@@ -170,11 +171,11 @@ module.exports = function getMappings() {
           objectPath.set(spec, "axes.0.title", undefined);
           objectPath.set(spec, "height", spec.height - 20); // decrease the height because we do not need space for the axis title
         }
-      }
+      },
     },
     {
       path: "item.options.lineChartOptions.minValue",
-      mapToSpec: function(minValue, spec, mappingData) {
+      mapToSpec: function (minValue, spec, mappingData) {
         // check if we need to shorten the number labels
         const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
@@ -185,11 +186,11 @@ module.exports = function getMappings() {
 
         objectPath.set(spec, "scales.1.nice", false);
         objectPath.set(spec, "scales.1.domainMin", minValue / divisor);
-      }
+      },
     },
     {
       path: "item.options.lineChartOptions.maxValue",
-      mapToSpec: function(maxValue, spec, mappingData) {
+      mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
         const divisor = dataHelpers.getDivisor(mappingData.item.data);
 
@@ -200,19 +201,19 @@ module.exports = function getMappings() {
 
         objectPath.set(spec, "scales.1.nice", false);
         objectPath.set(spec, "scales.1.domainMax", maxValue / divisor);
-      }
+      },
     },
     {
       path: "item.options.lineChartOptions.reverseYScale",
-      mapToSpec: function(reverseYScale, spec) {
+      mapToSpec: function (reverseYScale, spec) {
         if (reverseYScale === true) {
           objectPath.set(spec, "scales.1.reverse", true);
         }
-      }
+      },
     },
     {
       path: "item.options.lineChartOptions.lineInterpolation",
-      mapToSpec: function(interpolation, spec) {
+      mapToSpec: function (interpolation, spec) {
         if (interpolation) {
           objectPath.set(
             spec,
@@ -220,11 +221,11 @@ module.exports = function getMappings() {
             interpolation
           );
         }
-      }
+      },
     },
     {
       path: "item.options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, mappingData) {
+      mapToSpec: function (prognosisStart, spec, mappingData) {
         if (prognosisStart === null) {
           return;
         }
@@ -234,25 +235,25 @@ module.exports = function getMappings() {
           value: dateSeries.getPrognosisStartDate(
             mappingData.originalItemData,
             prognosisStart
-          )
+          ),
         });
 
         // split the marks at the prognosisStart index
         const lineMark = clone(spec.marks[0].marks[0]);
         lineMark.encode.enter.defined = {
-          signal: "datum.yValue !== null && datum.xValue <= prognosisStartDate"
+          signal: "datum.yValue !== null && datum.xValue <= prognosisStartDate",
         };
         const lineMarkPrognosis = clone(spec.marks[0].marks[0]);
         lineMarkPrognosis.encode.enter.defined = {
-          signal: "datum.yValue !== null && datum.xValue >= prognosisStartDate"
+          signal: "datum.yValue !== null && datum.xValue >= prognosisStartDate",
         };
         lineMarkPrognosis.style = "prognosisLine";
         spec.marks[0].marks = [lineMark, lineMarkPrognosis];
-      }
+      },
     },
     {
       path: "item.options.lineChartOptions.isStockChart",
-      mapToSpec: function(isStockChart, spec, mappingData) {
+      mapToSpec: function (isStockChart, spec, mappingData) {
         const item = mappingData.item;
         if (!isStockChart) {
           return;
@@ -273,11 +274,13 @@ module.exports = function getMappings() {
         objectPath.set(
           spec,
           "data.0.values",
-          objectPath.get(spec, "data.0.values").map(row => {
+          objectPath.get(spec, "data.0.values").map((row) => {
             row.xValue = row.xValue.valueOf();
             return row;
           })
         );
+        // Also use timestamps for events
+        convertDateObjectsToTimestamps(item.events);
 
         objectPath.set(spec, "axes.0.labelFlush", true);
 
@@ -287,15 +290,15 @@ module.exports = function getMappings() {
 
         objectPath.set(spec, "axes.0.values", [
           first.valueOf(),
-          last.valueOf()
+          last.valueOf(),
         ]);
 
         // the axis tick values should be formatted according to the selected interval
         objectPath.set(spec, "axes.0.encode.labels.update.text", {
-          signal: `formatDateForInterval(datum.value, '${interval}')`
+          signal: `formatDateForInterval(datum.value, '${interval}')`,
         });
-      }
-    }
+      },
+    },
   ]
     .concat(commonMappings.getLineDateSeriesHandlingMappings())
     .concat(commonMappings.getHeightMappings())

--- a/helpers/events.js
+++ b/helpers/events.js
@@ -24,19 +24,28 @@ function dateFieldsForEvent(event) {
 }
 
 function cloneEvents(originalEvents) {
-  return originalEvents.map(originalEvent => {
+  return originalEvents.map((originalEvent) => {
     return { ...originalEvent };
   });
 }
 
 function convertDateObjects(events) {
-  events.forEach(event => {
-    dateFieldsForEvent(event).forEach(dateField => {
+  events.forEach((event) => {
+    dateFieldsForEvent(event).forEach((dateField) => {
       const format =
         dateSeries.dateFormats[
           dateSeries.getDateFormatForValue(event[dateField])
         ];
       event[dateField] = format.getDate(event[dateField].match(format.parse));
+    });
+  });
+}
+
+function convertDateObjectsToTimestamps(events) {
+  // Convert date objects to timestamps for intraday-charts which do not use a real time axis
+  events.forEach((event) => {
+    dateFieldsForEvent(event).forEach((dateField) => {
+      event[dateField] = event[dateField].valueOf();
     });
   });
 }
@@ -57,8 +66,8 @@ function parseEvents(item) {
 
 function getAllDates(events) {
   const allDates = [];
-  events.forEach(event => {
-    dateFieldsForEvent(event).forEach(dateField => {
+  events.forEach((event) => {
+    dateFieldsForEvent(event).forEach((dateField) => {
       allDates.push(event[dateField]);
     });
   });
@@ -68,10 +77,10 @@ function getAllDates(events) {
 function filterEventsWithDateInData(events, data) {
   const parsedDatesData = dateSeries.getDataWithDateParsedAndSortedByDate(data);
   const dates = dateSeries.getFirstColumnSerie(parsedDatesData);
-  const times = new Set(dates.map(date => date.getTime()));
+  const times = new Set(dates.map((date) => date.getTime()));
 
-  return events.filter(event => {
-    return dateFieldsForEvent(event).every(dateField => {
+  return events.filter((event) => {
+    return dateFieldsForEvent(event).every((dateField) => {
       const eventTime = event[dateField].getTime();
       return times.has(eventTime);
     });
@@ -91,7 +100,7 @@ function extendWithEventDates(originalData, events) {
   }
   const data = [...originalData];
   const dateRange = dateSeries.getFirstAndLastDateFromData(data);
-  getAllDates(events).forEach(date => {
+  getAllDates(events).forEach((date) => {
     if (date < dateRange.first || date > dateRange.last) {
       // Put event date in first column, add second column with "null" data to ensure that the row is taken into account
       // for the x axis scale (important if event date is before the first or after the last date of the chart data)
@@ -119,12 +128,12 @@ function vegaSpecData(events) {
   return [
     {
       name: "events-point",
-      values: pointEventValues
+      values: pointEventValues,
     },
     {
       name: "events-range",
-      values: rangeEventValues
-    }
+      values: rangeEventValues,
+    },
   ];
 }
 
@@ -152,16 +161,16 @@ function verticalMarks(item, config) {
       encode: {
         enter: {
           x: {
-            signal: xFrom
+            signal: xFrom,
           },
           x2: {
-            signal: xTo
+            signal: xTo,
           },
           y: { value: -(diameter + 1.5) },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       name: "events-range-from",
@@ -174,9 +183,9 @@ function verticalMarks(item, config) {
           y2: yBottom,
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -188,9 +197,9 @@ function verticalMarks(item, config) {
           y2: { field: "y2" },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       name: "events-range-to",
@@ -203,9 +212,9 @@ function verticalMarks(item, config) {
           y2: yBottom,
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -217,9 +226,9 @@ function verticalMarks(item, config) {
           y2: { field: "y2" },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "symbol",
@@ -231,9 +240,9 @@ function verticalMarks(item, config) {
           size: { value: diameter * diameter },
           fill: { value: config.backgroundColor },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "text",
@@ -247,9 +256,9 @@ function verticalMarks(item, config) {
           fill: { value: config.foregroundColor },
           fontSize: { value: config.fontSize },
           fontWeight: { value: config.fontWeight },
-          text: { signal: "datum.datum.index + 1" }
-        }
-      }
+          text: { signal: "datum.datum.index + 1" },
+        },
+      },
     },
     {
       name: "events-point-line",
@@ -259,15 +268,15 @@ function verticalMarks(item, config) {
         enter: {
           x: {
             signal:
-              "floor(scale('xScale', datum.date) + bandwidth('xScale') / 2) + 0.5"
+              "floor(scale('xScale', datum.date) + bandwidth('xScale') / 2) + 0.5",
           },
           y: { value: -(config.radius + 2) },
           y2: yBottom,
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -279,9 +288,9 @@ function verticalMarks(item, config) {
           y2: { field: "y2" },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "symbol",
@@ -292,9 +301,9 @@ function verticalMarks(item, config) {
           y: { value: -(diameter + 2) },
           size: { value: diameter * diameter },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "text",
@@ -308,10 +317,10 @@ function verticalMarks(item, config) {
           fill: { value: config.foregroundColor },
           fontSize: { value: config.fontSize },
           fontWeight: { value: config.fontWeight },
-          text: { signal: "datum.datum.index + 1" }
-        }
-      }
-    }
+          text: { signal: "datum.datum.index + 1" },
+        },
+      },
+    },
   ];
 }
 
@@ -325,17 +334,17 @@ function horizontalMarks(config) {
       encode: {
         enter: {
           y: {
-            signal: "floor(scale('yScale', datum.dateFrom)) + 0.5"
+            signal: "floor(scale('yScale', datum.dateFrom)) + 0.5",
           },
           y2: {
             signal:
-              "floor(scale('yScale', datum.dateTo) + bandwidth('yScale')) - 0.5"
+              "floor(scale('yScale', datum.dateTo) + bandwidth('yScale')) - 0.5",
           },
           x: { field: { group: "width", level: 1 }, offset: diameter + 1.5 },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       name: "events-range-from",
@@ -348,9 +357,9 @@ function horizontalMarks(config) {
           x2: { field: { group: "width", level: 1 }, offset: diameter + 1 },
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -362,9 +371,9 @@ function horizontalMarks(config) {
           x2: { field: "x2", offset: 1 },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       name: "events-range-to",
@@ -377,9 +386,9 @@ function horizontalMarks(config) {
           x2: { field: "x" },
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -391,9 +400,9 @@ function horizontalMarks(config) {
           x2: { field: "x2", offset: 1 },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "symbol",
@@ -405,9 +414,9 @@ function horizontalMarks(config) {
           size: { value: diameter * diameter },
           fill: { value: config.backgroundColor },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "text",
@@ -421,9 +430,9 @@ function horizontalMarks(config) {
           fill: { value: config.foregroundColor },
           fontSize: { value: config.fontSize },
           fontWeight: { value: config.fontWeight },
-          text: { signal: "datum.datum.index + 1" }
-        }
-      }
+          text: { signal: "datum.datum.index + 1" },
+        },
+      },
     },
     {
       name: "events-point-line",
@@ -433,18 +442,18 @@ function horizontalMarks(config) {
         enter: {
           y: {
             signal:
-              "floor(scale('yScale', datum.date) + bandwidth('yScale') / 2) + 0.5"
+              "floor(scale('yScale', datum.date) + bandwidth('yScale') / 2) + 0.5",
           },
           x: { scale: "xScale", value: 0 },
           x2: {
             field: { group: "width", level: 1 },
-            offset: config.radius + 2
+            offset: config.radius + 2,
           },
           stroke: { value: config.backgroundColor },
           strokeOpacity: { value: 0.5 },
-          strokeWidth: { value: 3 }
-        }
-      }
+          strokeWidth: { value: 3 },
+        },
+      },
     },
     {
       type: "rule",
@@ -456,9 +465,9 @@ function horizontalMarks(config) {
           x2: { field: "x2" },
           stroke: { value: config.foregroundColor },
           strokeDash: { value: [1, 1] },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "symbol",
@@ -469,9 +478,9 @@ function horizontalMarks(config) {
           x: { field: "x2", offset: config.radius },
           size: { value: diameter * diameter },
           stroke: { value: config.foregroundColor },
-          strokeWidth: { value: 1 }
-        }
-      }
+          strokeWidth: { value: 1 },
+        },
+      },
     },
     {
       type: "text",
@@ -485,20 +494,21 @@ function horizontalMarks(config) {
           fill: { value: config.foregroundColor },
           fontSize: { value: config.fontSize },
           fontWeight: { value: config.fontWeight },
-          text: { signal: "datum.datum.index + 1" }
-        }
-      }
-    }
+          text: { signal: "datum.datum.index + 1" },
+        },
+      },
+    },
   ];
 }
 
 module.exports = {
   availableForItem,
+  convertDateObjectsToTimestamps,
   extendWithEventDates,
   filterEventsWithDateInData,
   filterEventsForChartType,
   parseEvents,
   vegaSpecData,
   verticalMarks,
-  horizontalMarks
+  horizontalMarks,
 };

--- a/resources/fixtures/data/line-stock-chart.json
+++ b/resources/fixtures/data/line-stock-chart.json
@@ -2259,6 +2259,19 @@
       "1935.5"
     ]
   ],
+  "events": [
+    {
+      "type": "point",
+      "date": "03/08/2018 09:00",
+      "label": "Start of second day"
+    },
+    {
+      "type": "range",
+      "dateFrom": "03/14/2018 09:05",
+      "dateTo": "03/14/2018 13:00",
+      "label": "Last day"
+    }
+  ],
   "sources": [
     {
       "link": {


### PR DESCRIPTION
### Fix: Handle event annotations of intraday charts

Problem: Intraday charts do not have a linear time axis, because the stock market is closed during the night.
Instead, there is a "jump" during the night, such that e.g. Thursday 16:50 => 17:00 is the same step on the x axis as Thursday 17:00 => Friday 8:00.

This situation was not properly handled for event annotations before and is fixed here.

Event annotations are also added to the stock chart fixture for testing.

See https://3.basecamp.com/3500782/buckets/1333707/todos/3077999117

Deployed on staging with relevant example here: https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d06c6f4