### PR TITLE
Add notification for valid date format

### DIFF
--- a/resources/locales/de/translation.json
+++ b/resources/locales/de/translation.json
@@ -20,6 +20,10 @@
       "title": "Sehr viele Spalten",
       "body": "Wenn Labels sich überlappen, solltest du die Option «Balken für mobile» oder «Balken statt Säulen» anwählen."
     },
+    "supportedDateFormat": {
+      "title": "Gültiges Datumsformat",
+      "body": "Spalte A enthält Daten in einem gültigen Datumsformat. Die Optionen für Datumsreihen können verwendet werden."
+    },
     "unsupportedDateFormat": {
       "title": "Ungültiges Datumsformat",
       "body": "Spalte A enthält wahrscheinlich ein nicht unterstütztes Datumsformat. Bitte konsultiere das Handbuch für eine Übersicht der unterstützten Formate."

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -20,6 +20,10 @@
       "title": "Many columns",
       "body": "If labels are overlapping, you should select the option «Bars for mobile» or «Bars instead of columns»."
     },
+    "supportedDateFormat": {
+      "title": "Supported date format",
+      "body": "Column A contains data in a valid date format. The date series options can be used."
+    },
     "unsupportedDateFormat": {
       "title": "Unsupported date format",
       "body": "Column A probably contains an unsupported date format. Please check the handbook for a list of supported formats."

--- a/resources/locales/fr/translation.json
+++ b/resources/locales/fr/translation.json
@@ -20,6 +20,10 @@
       "title": "Beaucoup de colonnes",
       "body": "Si les étiquettes se chevauchent, vous devez sélectionner l'option «Bars for mobile» ou «Bars au lieu des colonnes»."
     },
+    "supportedDateFormat": {
+      "title": "Format de date valide",
+      "body": "La colonne A contient des données dans un format de date valide. Les options de série de dates peuvent être utilisées."
+    },
     "unsupportedDateFormat": {
       "title": "Format de date invalide",
       "body": "La colonne A contient probablement un format de date non pris en charge. Veuillez consulter le manuel pour une liste des formats supportés."

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -69,6 +69,20 @@
               "type": "medium",
               "value": 3
             }
+          },
+          {
+            "type": "ToolEndpoint",
+            "config": {
+              "endpoint": "notification/supportedDateFormat",
+              "fields": ["data"],
+              "options": {
+                "limit": 8
+              }
+            },
+            "priority": {
+              "type": "low",
+              "value": 3
+            }
           }
         ]
       },

--- a/routes/notification/supportedDateFormat.js
+++ b/routes/notification/supportedDateFormat.js
@@ -1,0 +1,34 @@
+const Joi = require("@hapi/joi");
+const helpers = require("../../helpers/dateSeries.js");
+
+module.exports = {
+  method: "POST",
+  path: "/notification/supportedDateFormat",
+  options: {
+    validate: {
+      options: {
+        allowUnknown: true,
+      },
+      payload: Joi.object().required(),
+    },
+    cors: true,
+    tags: ["api"],
+  },
+  handler: function (request, h) {
+    try {
+      const item = request.payload.item;
+      if (helpers.isDateSeriesData(item.data)) {
+        return {
+          message: {
+            title: "notifications.supportedDateFormat.title",
+            body: "notifications.supportedDateFormat.body",
+          },
+        };
+      }
+
+      return null;
+    } catch (err) {
+      return null;
+    }
+  },
+};

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -10,6 +10,7 @@ module.exports = [
   require("./fixtures/data.js"),
   require("./notification/dateNotInData.js"),
   require("./notification/hideAxisLabel.js"),
+  require("./notification/supportedDateFormat"),
   require("./notification/unsupportedDateFormat"),
   require("./notification/unsupportedDateFormatEvents"),
   require("./notification/shouldBeBarChart.js"),
@@ -17,5 +18,5 @@ module.exports = [
   require("./notification/shouldBeBars.js"),
   require("./locales.js"),
   require("./data.js"),
-  require("./migration.js")
+  require("./migration.js"),
 ].concat(require("./schema.js"));


### PR DESCRIPTION
### Problem
Our editors regularly enter data with an unsupported date format. Often they struggle to detect the problem by themselves, because Q doesn't provide any indication of a problem. There is already a notification which is shown when an unsupported date format is detected. But often Q can't detect an unsupported date format, because it's hard to create a logic which can differentiate between an unsupported date format and regular text.

### Possible solution
We are introducing a new notification which is always shown when a date format was detected. We will communicated this change to our editors and remind them of the documentation on supported date formats. If an editor enters date with a dateseries and the notification is not shown, they know that the date format is not supported.

This PR is deployed on test: https://q.st-test.nzz.ch/editor/chart/chart-44