### PR TITLE
Release 3.3.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function loadFonts(fonts) {
       fontFileBuffer
     );
     registerFont(`${__dirname}/resources/fonts/${font.filename}`, {
-      family: font.name
+      family: font.name,
     });
   }
 }
@@ -45,8 +45,8 @@ const Hapi = require("@hapi/hapi");
 const server = Hapi.server({
   port: process.env.PORT || 3000,
   routes: {
-    cors: true
-  }
+    cors: true,
+  },
 });
 
 const routes = require("./routes/routes.js");
@@ -55,10 +55,6 @@ async function init() {
   if (process.env.FONTS) {
     await loadFonts(JSON.parse(process.env.FONTS));
   }
-
-  // fiddle with canvas font: https://medium.com/@adamhooper/fonts-in-node-canvas-bbf0b6b0cabf
-  process.env.FONTCONFIG_PATH = `${__dirname}/resources/fonts`;
-  process.env.PANGOCAIRO_BACKEND = "fontconfig";
 
   testCanvasFontMeasure();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Fix font loading on macOS

Remove modification of the FONTCONFIG_PATH / PANGOCAIRO_BACKEND environment variables.
Starting with node-canvas v2, the modification of these settings is no longer required
according to https://medium.com/@adamhooper/fonts-in-node-canvas-bbf0b6b0cabf
We observed that fonts were not loaded from resources/fonts with these modified
environment variables on macOS.

With this change, fonts are loaded correctly on macOS and Ubuntu 18.

How to test
- Make sure that the nzz-sans-serif font is not installed in the system.
- Run the chart tool with the following entry in the FONTS array and verify
  that the measure width test displays 54