### PR TITLE
Feat large numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ This is only available for chartType `Bar`, `StackedBar`, `Line` and `Dotplot`. 
 The option is an array of objects with `color`, `colorLight` and `position` values. The `color` is used if no highlighting is in place. The `colorLight` is used if any other data series than the one at `position` is highlighted.
 This is only available if no `colorOverwritesSeries` is given.
 
+#### largeNumbers
+
+Options for how to handle large numbers, available for all chart types.
+
+##### divideBy
+
+One of `[0, 1, 1e3, 1e6, 1e9]`.
+
+- If `0` (default), the divisor is chosen automatically depending on the maximum value in the data, and (if applicable) `in Tausend`, `in Millionen`, `in Milliarden` is appended to the subtitle.
+- If not `0`, values are divided by the provided divisor, and the subtitle is not modified.
+
 ## LICENSE
 
 Copyright (c) 2019 Neue Zürcher Zeitung.

--- a/chartTypes/area/mapping.js
+++ b/chartTypes/area/mapping.js
@@ -7,12 +7,12 @@ module.exports = function getMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function(itemData, spec, mappingData) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -75,7 +75,7 @@ module.exports = function getMappings() {
       path: "item.options.areaChartOptions.maxValue",
       mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/arrow/mapping.js
+++ b/chartTypes/arrow/mapping.js
@@ -40,7 +40,7 @@ module.exports = function getMapping() {
         }
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -146,7 +146,7 @@ module.exports = function getMapping() {
       path: "item.options.arrowOptions.minValue",
       mapToSpec: function (minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
@@ -161,7 +161,7 @@ module.exports = function getMapping() {
       path: "item.options.arrowOptions.maxValue",
       mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -66,7 +66,7 @@ module.exports = function getMapping() {
         }
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -198,7 +198,7 @@ module.exports = function getMapping() {
       path: "item.options.barOptions.maxValue",
       mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/bar/mapping.js
+++ b/chartTypes/bar/mapping.js
@@ -74,7 +74,7 @@ module.exports = function getMapping() {
         }
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -346,7 +346,7 @@ module.exports = function getMapping() {
       path: "item.options.barOptions.maxValue",
       mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/column-stacked/mapping.js
+++ b/chartTypes/column-stacked/mapping.js
@@ -9,12 +9,12 @@ module.exports = function getMapping() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function(itemData, spec, mappingData) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -94,7 +94,7 @@ module.exports = function getMapping() {
       path: "item.options.barOptions.maxValue",
       mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/column/mapping.js
+++ b/chartTypes/column/mapping.js
@@ -14,12 +14,12 @@ module.exports = function getMapping() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function(itemData, spec, mappingData) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -72,7 +72,7 @@ module.exports = function getMapping() {
       path: "item.options.barOptions.maxValue",
       mapToSpec: function(maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/commonPrerender.js
+++ b/chartTypes/commonPrerender.js
@@ -8,7 +8,7 @@ const d3 = {
 function setFormatLocaleForNumberGrouping(item, toolRuntimeConfig, spec, vega) {
   // if we have one value >= 10000 in the Y Axis, we will group thousands
   try {
-    const divisor = dataHelpers.getDivisor(item.data);
+    const divisor = dataHelpers.getDivisor(item.data, item.options.largeNumbers);
 
     const minDataValue =
       spec.scales[1].maxValue ||

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -36,7 +36,7 @@ module.exports = function getMapping() {
         }
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
@@ -156,7 +156,7 @@ module.exports = function getMapping() {
       path: "item.options.dotplotOptions.minValue",
       mapToSpec: function (minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
@@ -171,7 +171,7 @@ module.exports = function getMapping() {
       path: "item.options.dotplotOptions.maxValue",
       mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -17,12 +17,12 @@ module.exports = function getMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function (itemData, spec) {
+      mapToSpec: function (itemData, spec, mappingData) {
         // set the x axis title
         objectPath.set(spec, "axes.0.title", itemData[0][0]);
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData);
+        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
 
         spec.data = [
           {
@@ -177,7 +177,7 @@ module.exports = function getMappings() {
       path: "item.options.lineChartOptions.minValue",
       mapToSpec: function (minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
@@ -192,7 +192,7 @@ module.exports = function getMappings() {
       path: "item.options.lineChartOptions.maxValue",
       mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data);
+        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {

--- a/helpers/data.js
+++ b/helpers/data.js
@@ -125,7 +125,14 @@ function getMinValue(data) {
   return Math.min.apply(null, flatData);
 }
 
-function getDivisor(data) {
+function hasManualDivisor(largeNumbers) {
+  return largeNumbers && largeNumbers.divideBy !== 0;
+}
+
+function getDivisor(data, largeNumbers) {
+  if (hasManualDivisor(largeNumbers)) {
+    return largeNumbers.divideBy;
+  }
   try {
     const minValue = getMinValue(data);
     const maxValue = getMaxValue(data);
@@ -147,6 +154,7 @@ module.exports = {
   getFlatData: getFlatData,
   getMaxValue: getMaxValue,
   getMinValue: getMinValue,
+  hasManualDivisor: hasManualDivisor,
   getDivisor: getDivisor,
   getWithOnlyStringsInFirstColumn: getWithOnlyStringsInFirstColumn
 };

--- a/helpers/data.js
+++ b/helpers/data.js
@@ -28,7 +28,7 @@ function getDataWithStringsCastedToFloats(data) {
 }
 
 function getWithOnlyStringsInFirstColumn(data) {
-  return data.map(row => {
+  return data.map((row) => {
     if (row[0] === null || row[0] === undefined) {
       row[0] = "";
     }
@@ -45,7 +45,7 @@ function getLongestDataLabel(mappingData, transposed = false) {
   const titleRow = data[0];
   titleRow.shift();
   return titleRow
-    .map(label => {
+    .map((label) => {
       if (!mappingData.dateFormat) {
         return label;
       }
@@ -93,7 +93,7 @@ function getDivisorForValue(value) {
     divisor = Math.pow(10, 9);
   } else if (value >= Math.pow(10, 6)) {
     divisor = Math.pow(10, 6);
-  } else if (value >= Math.pow(10, 4)) {
+  } else if (value >= Math.pow(10, 5)) {
     divisor = Math.pow(10, 3);
   }
   return divisor;
@@ -112,14 +112,14 @@ function getFlatData(data) {
 }
 
 function getMaxValue(data) {
-  const flatData = getFlatData(data).filter(value => {
+  const flatData = getFlatData(data).filter((value) => {
     return value !== null && value !== undefined;
   });
   return Math.max.apply(null, flatData);
 }
 
 function getMinValue(data) {
-  const flatData = getFlatData(data).filter(value => {
+  const flatData = getFlatData(data).filter((value) => {
     return value !== null && value !== undefined;
   });
   return Math.min.apply(null, flatData);
@@ -156,5 +156,5 @@ module.exports = {
   getMinValue: getMinValue,
   hasManualDivisor: hasManualDivisor,
   getDivisor: getDivisor,
-  getWithOnlyStringsInFirstColumn: getWithOnlyStringsInFirstColumn
+  getWithOnlyStringsInFirstColumn: getWithOnlyStringsInFirstColumn,
 };

--- a/resources/fixtures/data/bar-large-numbers-auto.json
+++ b/resources/fixtures/data/bar-large-numbers-auto.json
@@ -1,0 +1,49 @@
+{
+  "title": "FIXTURE: Bar - large numbers - automatic",
+  "acronym": "rkz.",
+  "data": [
+    ["Company", "Value"],
+    ["A Corp", "5000"],
+    ["B Inc", "18000"],
+    ["C & Sisters", "15000"]
+  ],
+  "allowDownloadData": false,
+  "events": [],
+  "sources": [],
+  "options": {
+    "chartType": "Bar",
+    "hideAxisLabel": true,
+    "highlightDataSeries": [],
+    "highlightDataRows": [],
+    "annotations": {
+      "valuesOnBars": false
+    },
+    "barOptions": {
+      "isBarChart": false,
+      "forceBarsOnSmall": false
+    },
+    "dateSeriesOptions": {
+      "interval": "auto",
+      "labels": "few",
+      "prognosisStart": null
+    },
+    "lineChartOptions": {
+      "reverseYScale": false,
+      "lineInterpolation": "linear",
+      "isStockChart": false
+    },
+    "areaChartOptions": {
+      "areaInterpolation": "linear",
+      "stackType": "zero"
+    },
+    "dotplotOptions": {},
+    "arrowOptions": {
+      "colorScheme": 0
+    },
+    "colorOverwritesSeries": [],
+    "colorOverwritesRows": [],
+    "largeNumbers": {
+      "divideBy": 0
+    }
+  }
+}

--- a/resources/fixtures/data/bar-large-numbers-divide-by-1.json
+++ b/resources/fixtures/data/bar-large-numbers-divide-by-1.json
@@ -1,0 +1,49 @@
+{
+  "title": "FIXTURE: Bar - large numbers - divide by 1",
+  "acronym": "nth.",
+  "data": [
+    ["Kategorie", "Wert"],
+    ["Eins", "310090"],
+    ["Zwei", "999900"],
+    ["Drei", "300000"]
+  ],
+  "allowDownloadData": false,
+  "events": [],
+  "sources": [],
+  "options": {
+    "chartType": "Bar",
+    "hideAxisLabel": true,
+    "highlightDataSeries": [],
+    "highlightDataRows": [],
+    "annotations": {
+      "valuesOnBars": true
+    },
+    "barOptions": {
+      "isBarChart": true,
+      "forceBarsOnSmall": false
+    },
+    "dateSeriesOptions": {
+      "interval": "auto",
+      "labels": "few",
+      "prognosisStart": null
+    },
+    "lineChartOptions": {
+      "reverseYScale": false,
+      "lineInterpolation": "linear",
+      "isStockChart": false
+    },
+    "areaChartOptions": {
+      "areaInterpolation": "linear",
+      "stackType": "zero"
+    },
+    "dotplotOptions": {},
+    "arrowOptions": {
+      "colorScheme": 0
+    },
+    "colorOverwritesSeries": [],
+    "colorOverwritesRows": [],
+    "largeNumbers": {
+      "divideBy": 1
+    }
+  }
+}

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -99,5 +99,12 @@
   "Annotation": "Annotation",
   "Zeitspanne": "Time span",
   "Von": "From",
-  "Bis": "To"
+  "Bis": "To",
+  "Optionen für grosse Werte": "Options for large numbers",
+  "Grosse Werte teilen": "Divide large numbers",
+  "automatisch": "automatically",
+  "nicht teilen": "do not divide",
+  "durch 1000": "by 1000",
+  "durch 1 Million": "by 1 million",
+  "durch 1 Milliarde": "by 1 billion"
 }

--- a/resources/locales/fr/translation.json
+++ b/resources/locales/fr/translation.json
@@ -99,5 +99,12 @@
   "Annotation": "Annotation",
   "Zeitspanne": "Période de temps",
   "Von": "De",
-  "Bis": "À"
+  "Bis": "À",
+  "Optionen für grosse Werte": "Options pour les grands nombres",
+  "Grosse Werte teilen": "Diviser les grands nombres",
+  "automatisch": "automatiquement",
+  "nicht teilen": "ne pas diviser",
+  "durch 1000": "par 1000",
+  "durch 1 Million": "par 1 million",
+  "durch 1 Milliarde": "par 1 milliard"
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -961,7 +961,7 @@
           }
         },
         "largeNumbers": {
-          "title": "Optionen für Grosse Werte",
+          "title": "Optionen für grosse Werte",
           "type": "object",
           "properties": {
             "divideBy": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -959,6 +959,34 @@
               }
             }
           }
+        },
+        "largeNumbers": {
+          "title": "Optionen für Grosse Werte",
+          "type": "object",
+          "properties": {
+            "divideBy": {
+              "title": "Grosse Werte teilen",
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "enum": [0, 1, 1e3, 1e6, 1e9],
+              "default": "automatic",
+              "Q:options": {
+                "enum_titles": [
+                  "automatisch",
+                  "nicht teilen",
+                  "durch 1000",
+                  "durch 1 Million",
+                  "durch 1 Milliarde"
+                ]
+              }
+            }
+          }
         }
       }
     }

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -17,6 +17,8 @@ const fixtureData = [
   require(`${fixtureDataDirectory}/bar-dates-null-values.json`),
   require(`${fixtureDataDirectory}/bar-dates-quarter.json`),
   require(`${fixtureDataDirectory}/bar-dates-years.json`),
+  require(`${fixtureDataDirectory}/bar-large-numbers-auto.json`),
+  require(`${fixtureDataDirectory}/bar-large-numbers-divide-by-1.json`),
   require(`${fixtureDataDirectory}/bar-maxValue.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-negative-only.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-negative.json`),

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -88,8 +88,9 @@ module.exports = {
     }
 
     // check if we need to add a subtitle suffix because we will shorten the numbers for Y Axis
+    const hasManualDivisor = item.options.largeNumbers && item.options.largeNumbers.divideBy !== 0;
     const divisor = dataHelpers.getDivisor(item.data);
-    if (divisor > 1) {
+    if (!hasManualDivisor && divisor > 1) {
       if (item.subtitle && item.subtitle !== "") {
         item.subtitleSuffix = ` (in ${dataHelpers.getDivisorString(divisor)})`;
       } else {

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -87,14 +87,15 @@ module.exports = {
       }
     }
 
-    // check if we need to add a subtitle suffix because we will shorten the numbers for Y Axis
-    const hasManualDivisor = item.options.largeNumbers && item.options.largeNumbers.divideBy !== 0;
-    const divisor = dataHelpers.getDivisor(item.data);
-    if (!hasManualDivisor && divisor > 1) {
-      if (item.subtitle && item.subtitle !== "") {
-        item.subtitleSuffix = ` (in ${dataHelpers.getDivisorString(divisor)})`;
-      } else {
-        item.subtitleSuffix = `in ${dataHelpers.getDivisorString(divisor)}`;
+    if (!dataHelpers.hasManualDivisor(item.options.largeNumbers)) {
+      // check if we need to add a subtitle suffix because we will shorten the numbers for Y Axis
+      const divisor = dataHelpers.getDivisor(item.data, item.options.largeNumbers);
+      if (divisor > 1) {
+        if (item.subtitle && item.subtitle !== "") {
+          item.subtitleSuffix = ` (in ${dataHelpers.getDivisorString(divisor)})`;
+        } else {
+          item.subtitleSuffix = `in ${dataHelpers.getDivisorString(divisor)}`;
+        }
       }
     }
 


### PR DESCRIPTION
- Add `largeNumbers` => `divideBy` option, including fixture data, documentation, and translations
- Adapt logic for automatic divisor: Keep full numbers up to 99 999, divide if >= 100k