### PR TITLE
Fix area chart number format

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,18 @@
       },
       "runtimeVersion": "12.10.0",
       "program": "${workspaceRoot}/test/e2e-tests.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch dom Tests",
+      "env": {
+        "DEBUG": true,
+        "DIVERGING_COLOR_SCHEMES": "[{ \"label\": \"one\", \"key\": 0, \"scheme_name\": \"diverging_one\" }, { \"label\": \"two\", \"key\": 1, \"scheme_name\": \"diverging_two\" }, { \"label\": \"three\", \"key\": 2, \"scheme_name\": \"diverging_three\" } ]",
+        "FONTS": "[{\"url\": \"https://assets.static-nzz.ch/nzz-niobe/assets/fonts/GT-America-Standard-Regular.otf\",\"name\": \"nzz-sans-serif\",\"filename\": \"nzz-sans-serif.otf\"}]"
+      },
+      "runtimeVersion": "12.10.0",
+      "program": "${workspaceRoot}/test/dom-tests.js"
     }
   ]
 }

--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -105,8 +105,7 @@
       "ticks": false,
       "labels": true,
       "tickCount": 4,
-      "labelPadding": 2,
-      "format": "~r"
+      "labelPadding": 2
     }
   ],
   "marks": [

--- a/resources/fixtures/data/area-y-legend-thousand-separator.json
+++ b/resources/fixtures/data/area-y-legend-thousand-separator.json
@@ -1,0 +1,80 @@
+{
+  "title": "FIXTURE: Area - y legend thousand separator",
+  "data": [
+    [
+      "Jahr",
+      "A"
+    ],
+    [
+      "2012",
+      "1"
+    ],
+    [
+      "2013",
+      "20"
+    ],
+    [
+      "2014",
+      "300"
+    ],
+    [
+      "2015",
+      "2000"
+    ],
+    [
+      "2016",
+      "7501"
+    ],
+    [
+      "2017",
+      "10000"
+    ],
+    [
+      "2018",
+      "49999"
+    ],
+    [
+      "2019",
+      "50001"
+    ],
+    [
+      "2020",
+      "75111"
+    ],
+    [
+      "2021",
+      "99999"
+    ]
+  ],
+  "allowDownloadData": false,
+  "sources": [],
+  "options": {
+    "chartType": "Area",
+    "hideAxisLabel": true,
+    "highlightDataSeries": [],
+    "highlightDataRows": [],
+    "annotations": {},
+    "barOptions": {
+      "isBarChart": false,
+      "forceBarsOnSmall": false
+    },
+    "dateSeriesOptions": {
+      "interval": "auto",
+      "prognosisStart": 1
+    },
+    "lineChartOptions": {
+      "reverseYScale": false,
+      "lineInterpolation": "linear",
+      "isStockChart": false
+    },
+    "dotplotOptions": {},
+    "arrowOptions": {
+      "colorScheme": 0
+    },
+    "colorOverwritesSeries": [],
+    "colorOverwritesRows": [],
+    "areaChartOptions": {
+      "areaInterpolation": "linear"
+    }
+  }
+}

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -5,6 +5,7 @@ const fixtureDataDirectory = "../../resources/fixtures/data";
 const fixtureData = [
   require(`${fixtureDataDirectory}/area-three-categories-prognosis.json`),
   require(`${fixtureDataDirectory}/area-three-categories-y-max.json`),
+  require(`${fixtureDataDirectory}/area-y-legend-thousand-separator.json`),
   require(`${fixtureDataDirectory}/arrow-two-categories-only-negative.json`),
   require(`${fixtureDataDirectory}/arrow-two-categories-only-positive.json`),
   require(`${fixtureDataDirectory}/arrow-two-categories-same-value.json`),

--- a/test/config/toolRuntimeConfig.json
+++ b/test/config/toolRuntimeConfig.json
@@ -71,5 +71,13 @@
     "fontSize": 11,
     "fontWeight": 700,
     "radius": 8
+  },
+  "size": {
+    "width": [
+      {
+        "value": 272,
+        "comparison": "="
+      }
+    ]
   }
 }


### PR DESCRIPTION
Flag format in the vega configuration of the area was deleted. For the other charts, this was done in the following PR:
* #143
* #156
### Issue
* [Chart - Flächendiagramm kein viertelgeviert](https://3.basecamp.com/3500782/buckets/1333707/todos/3390763757)
### Example
* https://q.st-test.nzz.ch/item/chart-2