### PR TITLE
Fix annotation overflow label

### DIFF
--- a/styles_src/q-chart.scss
+++ b/styles_src/q-chart.scss
@@ -7,14 +7,14 @@
 }
 
 .q-chart-events {
-  margin: 0 4px;
+  margin-top: 4px;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
 }
 
-.q-chart-events__label {
-  display: flex;
-  align-items: center;
-  margin-left: 4px;
+.q-chart-events__icon {
+  height: 18px;
+  width: 18px;
+  margin-right: 4px
 }

--- a/styles_src/q-chart.scss
+++ b/styles_src/q-chart.scss
@@ -10,7 +10,6 @@
   margin-top: 4px;
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
 }
 
 .q-chart-events__icon {
@@ -20,5 +19,6 @@
 }
 
 .q-chart-events__label {
-  align-self: center;
+  display: flex;
+  align-items: center;
 }

--- a/styles_src/q-chart.scss
+++ b/styles_src/q-chart.scss
@@ -16,5 +16,9 @@
 .q-chart-events__icon {
   height: 18px;
   width: 18px;
-  margin-right: 4px
+  margin-right: 4px;
+}
+
+.q-chart-events__label {
+  align-self: center;
 }

--- a/views/events.html
+++ b/views/events.html
@@ -3,15 +3,18 @@
   style="margin: 15px -4px; display: flex; flex-wrap: wrap;"
 >
   {%- for event in events.data %}
-  <div class="q-chart q-chart-events" style="margin-right: 4px; margin-left: 4px">
+  <div class="q-chart-events" style="margin-right: 4px; margin-left: 4px;"
+  >
     {% set radius = events.config.radius %}
     <div class="q-chart-events__icon">
-      <svg width="{{ 2 * radius + 2 }}" height="{{ 2 * radius + 2 }}" style="vertical-align: sub;">
+      <svg width="{{ 2 * radius + 2 }}" height="{{ 2 * radius + 2 }}">
         <g transform="translate({{ radius + 1 }}, {{ radius + 1 }})">
-          <path
-            d="M{{ radius }},0A{{ radius }},{{ radius }},0,1,1,-{{ radius }},0A{{ radius }},{{ radius }},0,1,1,{{ radius }},0"
-            style="fill: none; stroke: currentColor; stroke-width: 1;"
-          ></path>
+          <circle
+            r="{{ radius }}"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1"
+          />
           <text
             y="4"
             text-anchor="middle"
@@ -23,6 +26,6 @@
       </svg>
     </div>
     <div class="q-chart-events__label">{{ event.label }}</div>
-  </div style="margin: 0 4px;">
+  </div>
   {%- endfor %}
 </div>

--- a/views/events.html
+++ b/views/events.html
@@ -3,24 +3,26 @@
   style="margin: 15px -4px; display: flex; flex-wrap: wrap;"
 >
   {%- for event in events.data %}
-  <div class="q-chart q-chart-events">
+  <div class="q-chart q-chart-events" style="margin-right: 4px; margin-left: 4px">
     {% set radius = events.config.radius %}
-    <svg width="{{ 2 * radius + 2 }}" height="{{ 2 * radius + 2 }}" style="vertical-align: sub;">
-      <g transform="translate({{ radius + 1 }}, {{ radius + 1 }})">
-        <path
-          d="M{{ radius }},0A{{ radius }},{{ radius }},0,1,1,-{{ radius }},0A{{ radius }},{{ radius }},0,1,1,{{ radius }},0"
-          style="fill: none; stroke: currentColor; stroke-width: 1;"
-        ></path>
-        <text
-          y="4"
-          text-anchor="middle"
-          style="font-size: {{ events.config.fontSize }}px; font-weight: {{ events.config.fontWeight }}; fill: currentColor;"
-        >
-          {{ loop.index }}
-        </text>
-      </g>
-    </svg>
-    <span class="q-chart q-chart-events__label">{{ event.label }}</span>
+    <div class="q-chart-events__icon">
+      <svg width="{{ 2 * radius + 2 }}" height="{{ 2 * radius + 2 }}" style="vertical-align: sub;">
+        <g transform="translate({{ radius + 1 }}, {{ radius + 1 }})">
+          <path
+            d="M{{ radius }},0A{{ radius }},{{ radius }},0,1,1,-{{ radius }},0A{{ radius }},{{ radius }},0,1,1,{{ radius }},0"
+            style="fill: none; stroke: currentColor; stroke-width: 1;"
+          ></path>
+          <text
+            y="4"
+            text-anchor="middle"
+            style="font-size: {{ events.config.fontSize }}px; font-weight: {{ events.config.fontWeight }}; fill: currentColor;"
+          >
+            {{ loop.index }}
+          </text>
+        </g>
+      </svg>
+    </div>
+    <div>{{ event.label }}</div>
   </div style="margin: 0 4px;">
   {%- endfor %}
 </div>

--- a/views/events.html
+++ b/views/events.html
@@ -22,7 +22,7 @@
         </g>
       </svg>
     </div>
-    <div>{{ event.label }}</div>
+    <div class="q-chart-events__label">{{ event.label }}</div>
   </div style="margin: 0 4px;">
   {%- endfor %}
 </div>


### PR DESCRIPTION
On mobile phones with small screen sizes, the label overlaps the icon.
Before fix:
<img width="320" alt="Screenshot 2021-02-11 at 15 17 04" src="https://user-images.githubusercontent.com/2006124/107647888-f01ad680-6c7b-11eb-84e5-09b2e8390806.png">
After fix
<img width="283" alt="Screenshot 2021-02-11 at 15 17 04" src="https://user-images.githubusercontent.com/2006124/107648172-45ef7e80-6c7c-11eb-9c3e-6a0a1e205951.png">

Example
* https://q.st-test.nzz.ch/item/chart-45
* https://www-test.nzz.ch/test/first-test-ld.1340834