### PR TITLE
Fix cut off axis labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get -y install build-essential libcairo2-dev libpango1
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 RUN npm install --production
-RUN npm install canvas --build-from-source
 
 # Copy everthing else in work directory
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get -y install build-essential libcairo2-dev libpango1
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 RUN npm install --production
+RUN npm install canvas --build-from-source
 
 # Copy everthing else in work directory
 COPY . /app

--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "autosize": {
-    "type": "fit"
+    "type": "fit",
+    "contains": "padding"
   },
   "height": 220,
   "data": [

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "autosize": {
-    "type": "fit"
+    "type": "fit",
+    "contains": "padding"
   },
   "height": 220,
   "scales": [

--- a/config/vega-default.json
+++ b/config/vega-default.json
@@ -15,5 +15,5 @@
     "labelLimit": false,
     "tickRound": true
   },
-  "padding": { "left": 4 }
+  "padding": { "left": 4, "right": 4 }
 }

--- a/config/vega-default.json
+++ b/config/vega-default.json
@@ -14,5 +14,6 @@
     "labelPadding": 8,
     "labelLimit": false,
     "tickRound": true
-  }
+  },
+  "padding": { "left": 4 }
 }

--- a/helpers/textMeasure.js
+++ b/helpers/textMeasure.js
@@ -3,26 +3,18 @@ const canvas = createCanvas(200, 200);
 const context = canvas.getContext("2d");
 
 function getLabelTextWidth(text, toolRuntimeConfig) {
-  context.font =
-    toolRuntimeConfig.text.fontWeight +
-    " " +
-    toolRuntimeConfig.text.fontSize +
-    " " +
-    toolRuntimeConfig.text.font;
+  // CanvasRenderingContext2D.font expects the font string to be same form as CSS font specifier - https://developer.mozilla.org/en-US/docs/Web/CSS/font
+  context.font = `${toolRuntimeConfig.text.fontWeight} ${toolRuntimeConfig.text.fontSize}px ${toolRuntimeConfig.text.font}`;
   return context.measureText(text).width;
 }
 
 function getAxisLabelTextWidth(text, toolRuntimeConfig) {
-  context.font =
-    toolRuntimeConfig.axis.labelFontWeight +
-    " " +
-    toolRuntimeConfig.axis.labelFontSize +
-    " " +
-    toolRuntimeConfig.axis.labelFont;
+  // CanvasRenderingContext2D.font expects the font string to be same form as CSS font specifier - https://developer.mozilla.org/en-US/docs/Web/CSS/font
+  context.font = `${toolRuntimeConfig.axis.labelFontWeight} ${toolRuntimeConfig.axis.labelFontSize}px ${toolRuntimeConfig.axis.labelFont}`;
   return context.measureText(text).width;
 }
 
 module.exports = {
   getLabelTextWidth,
-  getAxisLabelTextWidth
+  getAxisLabelTextWidth,
 };


### PR DESCRIPTION
This PR fixes a bug in the text measure logic. The chart tool uses the [node-canvas module](https://github.com/Automattic/node-canvas) to measure the width of a text label on server-side. This width is used to determine if a label should be hidden or how much space should be made available for the label. 

The bug was that font string that is passed to the canvas context looked like this before `context.font = "100 11 nzz-sans-serif"`. The font string has to follow the same logic as a regular [css font string](https://developer.mozilla.org/en-US/docs/Web/CSS/font). So it was missing the `px` for the font-size value. This PR fixes that to `context.font = "100 11px nzz-sans-serif"`. The canvas module couldn't parse this string before and used the default font string which is `10 sans-serif`. Which uses a sans-serif font which is installed on the system. 

This doesn't fully solve the issue of cut off axis labels though. Therefore this PR adds a padding of 4px to the left of the graphic. This fixes all reported cases of cut off axis labels on web and print versions.

Before: https://q.st.nzz.ch/item/340c84efacc301e257fa36acb658f192

<img width="308" alt="Screenshot 2021-02-17 at 21 07 21" src="https://user-images.githubusercontent.com/1810384/108261792-616af580-7164-11eb-9704-5d062b51d95c.png">

After: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d18f29c

<img width="310" alt="Screenshot 2021-02-17 at 21 08 35" src="https://user-images.githubusercontent.com/1810384/108261830-7051a800-7164-11eb-918d-2cf7dfc86ec8.png">

More item where this problem can be reproduced:
Before: https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d1927ce
After: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d1925e6
Before: https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d1922bf
After: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d191357
Before: https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d1900bb
After: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d190e9d

Basecamp ToDo: https://3.basecamp.com/3500782/buckets/1333707/todos/2273519802