### PR TITLE
Show start and end label on mobile if labels option is set to many

### DIFF
--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -74,9 +74,9 @@
       "domain": false,
       "grid": false,
       "labels": true,
-      "labelFlush": true,
-      "labelBound": false,
+      "labelFlush": 24,
       "labelFlushOffset": 0,
+      "labelBound": true,
       "labelOverlap": "parity",
       "labelSeparation": 4,
       "encode": {

--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -75,7 +75,7 @@
       "grid": false,
       "labels": true,
       "labelFlush": true,
-      "labelBound": true,
+      "labelBound": false,
       "labelFlushOffset": 0,
       "labelOverlap": "parity",
       "labelSeparation": 4,

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -58,9 +58,9 @@
       "domain": false,
       "grid": false,
       "labels": true,
-      "labelFlush": true,
-      "labelBound": false,
+      "labelFlush": 24,
       "labelFlushOffset": 0,
+      "labelBound": true,
       "labelOverlap": "parity",
       "labelSeparation": 4,
       "encode": {

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -59,7 +59,7 @@
       "grid": false,
       "labels": true,
       "labelFlush": true,
-      "labelBound": true,
+      "labelBound": false,
       "labelFlushOffset": 0,
       "labelOverlap": "parity",
       "labelSeparation": 4,


### PR DESCRIPTION
This PR improves visible labels on mobile if labels option is set to many for area and line charts. The `labelFlush` property is set to 24px. This value was determined through testing. The [labelFlush property ](https://vega.github.io/vega/docs/axes/) indicates if labels at the beginning or end of the axis should be aligned flush with the scale range. The number indicates a pixel distance threshold: labels with anchor coordinates within the threshold distance for an axis end-point will be flush-adjusted.

[Before:](https://q.st.nzz.ch/item/26356a1918b687a3e1a7ff0d5edeec77)

<img width="304" alt="Screenshot 2021-02-22 at 11 46 45" src="https://user-images.githubusercontent.com/1810384/108697853-acd62880-7503-11eb-87a6-ce1b6501bac1.png">

[After:](https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d19f37b)

<img width="311" alt="Screenshot 2021-02-22 at 11 47 23" src="https://user-images.githubusercontent.com/1810384/108697904-bf506200-7503-11eb-94b6-b5333adbd243.png">

This PR is deployed [on test](https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d19f37b)

