### PR TITLE
Fix dotplot overlap threshold

### DIFF
--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -6,6 +6,7 @@ const dataHelpers = require("../../helpers/data.js");
 const d3config = require("../../config/d3.js");
 
 const commonMappings = require("../commonMappings.js");
+const { group } = require("d3-array");
 
 module.exports = function getMapping() {
   return [
@@ -36,39 +37,36 @@ module.exports = function getMapping() {
         }
 
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(itemData, mappingData.item.options.largeNumbers);
+        const divisor = dataHelpers.getDivisor(
+          itemData,
+          item.options.largeNumbers
+        );
+
+        // estimate X domain
+        const maxDataValue = Math.max(dataHelpers.getMaxValue(item.data));
+        const minDataValue = Math.min(dataHelpers.getMinValue(item.data));
+        const maxValueRounder =
+          maxDataValue < 50
+            ? maxDataValue
+            : Math.ceil((maxDataValue + 1) / 10) * 10;
+        const minValueRounder =
+          minDataValue > -50
+            ? minDataValue
+            : Math.ceil((Math.abs(maxDataValue) + 1) / 10) * -10;
+
+        // estimate how many pixel is one data unit
+        const unitInPixel =
+          spec.width /
+          ((spec.scales[0].domainMax || Math.max(0, maxValueRounder)) -
+            (spec.scales[0].domainMin || Math.min(0, minValueRounder)));
 
         spec.data[0].values = clone(itemData)
           .slice(1) // take the header row out of the array
           .map((row, rowIndex) => {
             const x = row.shift(); // take the x axis value out of the row
 
-            // count the single occurences of the values in this row to see if we have duplicates
-            const valueOccurences = row.reduce((all, current) => {
-              return Object.assign(all, {
-                [current]: {
-                  occurences:
-                    ((all[current] && all[current].occurences) || 0) + 1,
-                },
-              });
-            }, {});
-
-            // if we have duplicate values, we add some correction factor here to calculate
-            // the circles position (stacked if same value)
-            // calculate the first correction factor
-            // this gives us a currentCorrectionFactor like this
-            // occurences   factors
-            // 1            0
-            // 2            -0.5 0.5
-            // 3            -1 0 1
-            // 4            -1.5 -0.5 0.5 1.5
-            // 5            -2 -1 0 1 2
-            for (let value in valueOccurences) {
-              valueOccurences[value].currentCorrectionFactor =
-                (valueOccurences[value].occurences - 1) * -0.5;
-            }
-
-            return row
+            // the row to return
+            const dataRow = row
               .map((value, index) => {
                 // generate one array entry for every data category on the same x value
 
@@ -82,13 +80,7 @@ module.exports = function getMapping() {
                   xIndex: rowIndex,
                   yValue: shortenedValue,
                   cValue: index,
-                  posCorrectionFactor:
-                    valueOccurences[value].currentCorrectionFactor,
                 };
-
-                // increase the currentCorrectionFactor for this value by 1
-                valueOccurences[value].currentCorrectionFactor =
-                  valueOccurences[value].currentCorrectionFactor + 1;
 
                 return data;
               })
@@ -128,6 +120,91 @@ module.exports = function getMapping() {
                 } else {
                   data.diffToPrevious = null;
                 }
+
+                return data;
+              });
+
+            // group close values that would overlap
+            // we need to do this after diffToPrevious is calculated
+            // prepared group to spread later { number of elements, total value for smoothing }
+            const emptyThresholdGroup = { size: 0, totalValue: 0 };
+            // groups as array [ leading zero element, first group ]
+            const thresholdGroups = [0, { ...emptyThresholdGroup }];
+            let currentThresholdGroup = 1; // current group index
+            let diffFromFirstElement = 0; // accumulate difference from the first group element
+            // pixel size of the dot including stroke ( should be 14 but it seems to overlap with that)
+            const dotPixelSize = 15;
+            // go through the row in reverse, since diffToPrevious is used, it is simpler
+            // it also effects the visualisation later, arrange earliest-top and latest-bottom
+            for (let i = dataRow.length - 1; i > -1; i--) {
+              if (
+                (dataRow[i].diffToPrevious !== null &&
+                  dataRow[i].diffToPrevious * unitInPixel < dotPixelSize) ||
+                (dataRow[i + 1] &&
+                  dataRow[i + 1].diffToPrevious * unitInPixel < dotPixelSize)
+              ) {
+                // passed the threshold check
+                thresholdGroups[currentThresholdGroup].size++; // increment group size
+                thresholdGroups[currentThresholdGroup].totalValue +=
+                  dataRow[i].yValue; // add total group value
+                dataRow[i].thresholdGroup = currentThresholdGroup; // set data attribute for visualisation
+                diffFromFirstElement += dataRow[i].diffToPrevious; // add difference
+              }
+
+              // limit group based on size and distance difference
+              // start new group if needed
+              if (
+                dataRow[i].diffToPrevious * unitInPixel > dotPixelSize ||
+                thresholdGroups[currentThresholdGroup].size >
+                  (item.options.dotplotOptions.maxGroupSize - 1 || 3) ||
+                diffFromFirstElement * unitInPixel > dotPixelSize * 1.5
+              ) {
+                thresholdGroups.push({ ...emptyThresholdGroup });
+                currentThresholdGroup++;
+                diffFromFirstElement = 0;
+              }
+            }
+
+            // if we have grouped values, we add some correction factor here to calculate
+            // the circles position (stacked if similar value)
+            // calculate the first correction factor
+            // this gives us a currentCorrectionFactor like this
+            // groupsize    factors
+            // 1            0
+            // 2            -0.5 0.5
+            // 3            -1 0 1
+            // 4            -1.5 -0.5 0.5 1.5
+            // 5            -2 -1 0 1 2
+            const thresholdCorrectionValues = [];
+            // we also calculate the smooth value (avarage)
+            const thresholdSmoothValues = [];
+
+            thresholdGroups.map((group) => {
+              if (group.size > 0) {
+                thresholdCorrectionValues.push((group.size - 1) * -0.5);
+                thresholdSmoothValues.push(
+                  Math.round(group.totalValue / group.size)
+                );
+              } else {
+                thresholdCorrectionValues.push(0);
+                thresholdSmoothValues.push(0);
+              }
+            });
+
+            return dataRow
+              .map((data) => {
+                // smooth values
+                if (mappingData.item.options.dotplotOptions.smoothing) {
+                  data.yValue =
+                    thresholdSmoothValues[data.thresholdGroup] || data.yValue;
+                }
+                // set the correction factor for all data
+                data.posCorrectionFactor =
+                  thresholdCorrectionValues[data.thresholdGroup] || 0;
+                // add one to the correction values
+                // so the next in group will be offset
+                thresholdCorrectionValues[data.thresholdGroup]++;
+
                 return data;
               })
               .sort((a, b) => {
@@ -156,7 +233,10 @@ module.exports = function getMapping() {
       path: "item.options.dotplotOptions.minValue",
       mapToSpec: function (minValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
+        const divisor = dataHelpers.getDivisor(
+          mappingData.item.data,
+          mappingData.item.options.largeNumbers
+        );
 
         const dataMinValue = dataHelpers.getMinValue(mappingData.item.data);
         if (dataMinValue < minValue) {
@@ -171,7 +251,10 @@ module.exports = function getMapping() {
       path: "item.options.dotplotOptions.maxValue",
       mapToSpec: function (maxValue, spec, mappingData) {
         // check if we need to shorten the number labels
-        const divisor = dataHelpers.getDivisor(mappingData.item.data, mappingData.item.options.largeNumbers);
+        const divisor = dataHelpers.getDivisor(
+          mappingData.item.data,
+          mappingData.item.options.largeNumbers
+        );
 
         const dataMaxValue = dataHelpers.getMaxValue(mappingData.item.data);
         if (dataMaxValue > maxValue) {
@@ -396,6 +479,12 @@ module.exports = function getMapping() {
         spec.marks[0].marks[0].marks.push(diffTextMarksSpec);
       },
     },
+    // {
+    //   path: "item.options.dotPlotOptions.smoothing",
+    //   mapToSpec: function( smoothing, spec, mappingData ){
+    //     objectPath.set(spec, "smoothing", smoothing )
+    //   }
+    //}
   ]
     .concat(commonMappings.getColorOverwritesRowsMappings())
     .concat(commonMappings.getHighlightRowsMapping())

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -133,15 +133,15 @@ module.exports = function getMapping() {
             let currentThresholdGroup = 1; // current group index
             let diffFromFirstElement = 0; // accumulate difference from the first group element
             // pixel size of the dot including stroke ( should be 14 but it seems to overlap with that)
-            const dotPixelSize = 15;
+            const overlapTolerance = 10;
             // go through the row in reverse, since diffToPrevious is used, it is simpler
             // it also effects the visualisation later, arrange earliest-top and latest-bottom
             for (let i = dataRow.length - 1; i > -1; i--) {
               if (
                 (dataRow[i].diffToPrevious !== null &&
-                  dataRow[i].diffToPrevious * unitInPixel < dotPixelSize) ||
+                  dataRow[i].diffToPrevious * unitInPixel < overlapTolerance) ||
                 (dataRow[i + 1] &&
-                  dataRow[i + 1].diffToPrevious * unitInPixel < dotPixelSize)
+                  dataRow[i + 1].diffToPrevious * unitInPixel < overlapTolerance)
               ) {
                 // passed the threshold check
                 thresholdGroups[currentThresholdGroup].size++; // increment group size
@@ -154,10 +154,8 @@ module.exports = function getMapping() {
               // limit group based on size and distance difference
               // start new group if needed
               if (
-                dataRow[i].diffToPrevious * unitInPixel > dotPixelSize ||
-                thresholdGroups[currentThresholdGroup].size >
-                  (item.options.dotplotOptions.maxGroupSize - 1 || 3) ||
-                diffFromFirstElement * unitInPixel > dotPixelSize * 1.5
+                dataRow[i].diffToPrevious * unitInPixel > overlapTolerance ||
+                diffFromFirstElement * unitInPixel > overlapTolerance * 1.5
               ) {
                 thresholdGroups.push({ ...emptyThresholdGroup });
                 currentThresholdGroup++;
@@ -193,11 +191,9 @@ module.exports = function getMapping() {
 
             return dataRow
               .map((data) => {
-                // smooth values
-                if (mappingData.item.options.dotplotOptions.smoothing) {
-                  data.yValue =
-                    thresholdSmoothValues[data.thresholdGroup] || data.yValue;
-                }
+                // smooth/aggregate values
+                data.yValue =
+                  thresholdSmoothValues[data.thresholdGroup] || data.yValue;
                 // set the correction factor for all data
                 data.posCorrectionFactor =
                   thresholdCorrectionValues[data.thresholdGroup] || 0;
@@ -478,13 +474,7 @@ module.exports = function getMapping() {
         };
         spec.marks[0].marks[0].marks.push(diffTextMarksSpec);
       },
-    },
-    // {
-    //   path: "item.options.dotPlotOptions.smoothing",
-    //   mapToSpec: function( smoothing, spec, mappingData ){
-    //     objectPath.set(spec, "smoothing", smoothing )
-    //   }
-    //}
+    }
   ]
     .concat(commonMappings.getColorOverwritesRowsMappings())
     .concat(commonMappings.getHighlightRowsMapping())

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -177,26 +177,17 @@ module.exports = function getMapping() {
             // these values would be exactly dot size correction
             // since we want to clamp them more together, we use 0.4 instead of 0.5
             const thresholdCorrectionValues = [];
-            // we also calculate the smooth value (avarage)
-            const thresholdSmoothValues = [];
 
             thresholdGroups.map((group) => {
               if (group.size > 0) {
                 thresholdCorrectionValues.push((group.size - 1) * -0.4);
-                thresholdSmoothValues.push(
-                  Math.round(group.totalValue / group.size)
-                );
               } else {
                 thresholdCorrectionValues.push(0);
-                thresholdSmoothValues.push(0);
               }
             });
 
             return dataRow
               .map((data) => {
-                // smooth/aggregate values
-                data.yValue =
-                  thresholdSmoothValues[data.thresholdGroup] || data.yValue;
                 // set the correction factor for all data
                 data.posCorrectionFactor =
                   thresholdCorrectionValues[data.thresholdGroup] || 0;

--- a/chartTypes/dotplot/mapping.js
+++ b/chartTypes/dotplot/mapping.js
@@ -141,7 +141,8 @@ module.exports = function getMapping() {
                 (dataRow[i].diffToPrevious !== null &&
                   dataRow[i].diffToPrevious * unitInPixel < overlapTolerance) ||
                 (dataRow[i + 1] &&
-                  dataRow[i + 1].diffToPrevious * unitInPixel < overlapTolerance)
+                  dataRow[i + 1].diffToPrevious * unitInPixel <
+                    overlapTolerance)
               ) {
                 // passed the threshold check
                 thresholdGroups[currentThresholdGroup].size++; // increment group size
@@ -166,20 +167,22 @@ module.exports = function getMapping() {
             // if we have grouped values, we add some correction factor here to calculate
             // the circles position (stacked if similar value)
             // calculate the first correction factor
-            // this gives us a currentCorrectionFactor like this
+            // this gives us a currentCorrectionFactor similar to the below table
             // groupsize    factors
             // 1            0
             // 2            -0.5 0.5
             // 3            -1 0 1
             // 4            -1.5 -0.5 0.5 1.5
             // 5            -2 -1 0 1 2
+            // these values would be exactly dot size correction
+            // since we want to clamp them more together, we use 0.4 instead of 0.5
             const thresholdCorrectionValues = [];
             // we also calculate the smooth value (avarage)
             const thresholdSmoothValues = [];
 
             thresholdGroups.map((group) => {
               if (group.size > 0) {
-                thresholdCorrectionValues.push((group.size - 1) * -0.5);
+                thresholdCorrectionValues.push((group.size - 1) * -0.4);
                 thresholdSmoothValues.push(
                   Math.round(group.totalValue / group.size)
                 );
@@ -199,7 +202,7 @@ module.exports = function getMapping() {
                   thresholdCorrectionValues[data.thresholdGroup] || 0;
                 // add one to the correction values
                 // so the next in group will be offset
-                thresholdCorrectionValues[data.thresholdGroup]++;
+                thresholdCorrectionValues[data.thresholdGroup] += 0.8;
 
                 return data;
               })
@@ -474,7 +477,7 @@ module.exports = function getMapping() {
         };
         spec.marks[0].marks[0].marks.push(diffTextMarksSpec);
       },
-    }
+    },
   ]
     .concat(commonMappings.getColorOverwritesRowsMappings())
     .concat(commonMappings.getHighlightRowsMapping())

--- a/resources/fixtures/data/dotplot-years-threshold.json
+++ b/resources/fixtures/data/dotplot-years-threshold.json
@@ -1,0 +1,94 @@
+{
+  "title": "FIXTURE: Dotplot - overlap threshold",
+  "data": [
+    [
+      "Jahr",
+      "15–19",
+      "20–24",
+      "25–29",
+      "30–34",
+      "35–39",
+      "40–44"
+    ],
+    [
+      "2006",
+      "0",
+      "30",
+      "0",
+      "30.5",
+      "0",
+      "29.6"
+    ],
+    [
+      "2007",
+      "21",
+      "22",
+      "33",
+      "34",
+      "77",
+      "78"
+    ],
+    [
+      "2008",
+      "1",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50"
+    ],
+    [
+      "2009",
+      "1",
+      "2",
+      "3",
+      "4",
+      "7",
+      "8"
+    ],
+    [
+      "2010",
+      "41",
+      "42",
+      "45",
+      "46",
+      "49",
+      "50"
+    ],
+    [
+      "2011",
+      "97",
+      "98",
+      "99",
+      "100",
+      "101",
+      "102"
+    ]
+  ],
+  "sources": [],
+  "options": {
+    "chartType": "Dotplot",
+    "hideAxisLabel": false,
+    "annotations": {
+      "max": true
+    },
+    "barOptions": {
+      "isBarChart": false,
+      "forceBarsOnSmall": false
+    },
+    "dateSeriesOptions": {
+      "interval": "year",
+      "prognosisStart": null
+    },
+    "lineChartOptions": {
+      "reverseYScale": false,
+      "lineInterpolation": "linear",
+      "isStockChart": false
+    },
+    "dotplotOptions": {
+      "smoothing": false
+    },
+    "highlightDataSeries": [],
+    "colorOverwritesSeries": []
+  }
+}

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -776,6 +776,16 @@
             "maxValue": {
               "title": "Maximaler Wert",
               "type": "number"
+            },
+            "smoothing":{
+              "title": "Überlappende Werte gruppieren",
+              "type": "boolean",
+              "default": false
+            },
+            "maxGroupSize":{
+              "title": "Maximale Gruppengrösse bei Überlappung",
+              "type": "number",
+              "default": 4
             }
           }
         },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -776,16 +776,6 @@
             "maxValue": {
               "title": "Maximaler Wert",
               "type": "number"
-            },
-            "smoothing":{
-              "title": "Überlappende Werte gruppieren",
-              "type": "boolean",
-              "default": false
-            },
-            "maxGroupSize":{
-              "title": "Maximale Gruppengrösse bei Überlappung",
-              "type": "number",
-              "default": 4
             }
           }
         },

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -40,6 +40,7 @@ const fixtureData = [
   require(`${fixtureDataDirectory}/dotplot-floating-point.json`),
   require(`${fixtureDataDirectory}/dotplot-two-categories-same-value-min-max.json`),
   require(`${fixtureDataDirectory}/dotplot-years.json`),
+  require(`${fixtureDataDirectory}/dotplot-years-threshold.json`),
   require(`${fixtureDataDirectory}/dotplot-many-rows-diff-on-top.json`),
   require(`${fixtureDataDirectory}/dotplot-many-rows.json`),
   require(`${fixtureDataDirectory}/line-annotation-min-max.json`),


### PR DESCRIPTION
Addresses the following issue: 
https://3.basecamp.com/3500782/buckets/1333707/todos/2372408275

Includes fixture tailored to the fix dotplot-years-threshold.json

Two main steps happened:
First estimating the pixel value, for which I try to evaluate the width/data unit ratio and come up with an estimation. Would be definitely nicer if there would be a better way in Vega. It still works in most cases.
Second I remove the occurrence check from the item loop and introduce the threshold check on the already sorted array. This way I could work with the difference between points and the estimated unit pixel to decide if they overlap enough or not. 