### PR TITLE
remove whitespace on top of subtitle

### DIFF
--- a/views/header.html
+++ b/views/header.html
@@ -1,9 +1,14 @@
 {% if displayOptions.hideTitle !== true %}
-<h3 class="s-q-item__title">{{ item.title }}</h3>
-{% endif %} {%- if (item.subtitle and item.subtitle !== '') or
-(item.subtitleSuffix and item.subtitleSuffix !== '')%}
-<div class="s-q-item__subtitle">
-  {{ item.subtitle }}{% if item.subtitleSuffix%}{{ item.subtitleSuffix }}{%
-  endif %}
-</div>
+  <h3 class="s-q-item__title">{{ item.title }}</h3>
+{% endif %}
+{%- if
+  (item.subtitle and item.subtitle !== '') or
+  (item.subtitleSuffix and item.subtitleSuffix !== '')
+%}
+  <div class="s-q-item__subtitle">
+    {{- item.subtitle }}
+    {% if item.subtitleSuffix %}
+      {{ item.subtitleSuffix }}
+    {% endif -%}
+  </div>
 {%- endif %}


### PR DESCRIPTION
The original issue was, that there was an unexplainable whitespace on top of the subtitle, when the chart was rendered as print version. Problem was a "nunjucks peculiarity" regarding whitespace-control (https://mozilla.github.io/nunjucks/templating.html#whitespace-control).

Test here: https://q.st-staging.nzz.ch/item/chart-52