### PR TITLE
Fix date format no leading zero

### DIFF
--- a/helpers/dateSeries.js
+++ b/helpers/dateSeries.js
@@ -331,7 +331,7 @@ function getDateFormatForSerie(serie) {
   const sortedFormats = Object.keys(detectedTypeFormatsCount).sort((a, b) => {
     return detectedTypeFormatsCount[b] - detectedTypeFormatsCount[a];
   });
-
+  
   // return the format with most detections
   return sortedFormats[0];
 }
@@ -612,7 +612,7 @@ const intervals = {
     },
   },
   day: {
-    d3format: "%d.%m.%Y",
+    d3format: "%-d.\u2009%-m.\u2009%-Y",
     vegaInterval: { interval: "day", step: 1 },
     label: "Tage",
     getFirstStepDateAfterDate: function (date) {

--- a/helpers/dateSeries.js
+++ b/helpers/dateSeries.js
@@ -331,7 +331,7 @@ function getDateFormatForSerie(serie) {
   const sortedFormats = Object.keys(detectedTypeFormatsCount).sort((a, b) => {
     return detectedTypeFormatsCount[b] - detectedTypeFormatsCount[a];
   });
-  
+
   // return the format with most detections
   return sortedFormats[0];
 }
@@ -639,7 +639,7 @@ const intervals = {
     },
   },
   hour: {
-    d3format: "%d.%m. %H Uhr",
+    d3format: "%-d.\u2009%-m. %H Uhr",
     vegaInterval: { interval: "hour", step: 1 },
     label: "Stunden",
     getFirstStepDateAfterDate: function (date) {
@@ -668,7 +668,7 @@ const intervals = {
     },
   },
   minute: {
-    d3format: "%d.%m. %H:%M Uhr",
+    d3format: "%-d.\u2009%-m. %H:%M Uhr",
     vegaInterval: { interval: "hour", step: 1 },
     label: "Minuten",
     getFirstStepDateAfterDate: function (date) {
@@ -713,7 +713,7 @@ const intervals = {
     },
   },
   second: {
-    d3format: "%d.%m. %H:%M:%S Uhr",
+    d3format: "%-d.\u2009%-m. %H:%M:%S Uhr",
     vegaInterval: { interval: "hour", step: 1 },
     label: "Sekunden",
     getFirstStepDateAfterDate: function (date) {


### PR DESCRIPTION
Addresses the following issue: 
https://3.basecamp.com/3500782/buckets/1333707/todos/3860502252

Despite the complicated nature of dates, the function for formatting with d3 made this an easy fix.
The changes in nutshell: the dash ( %d --> %-d ) means no spacing, overriding the default zero leading. The unicode character is the thin space (viertelgeviert).  

The change requested to be everywhere, where numeric day and month appears.
Tested on most charts with different dates (fixtures and charts on staging).
