### PR TITLE
fix axislabel overlap test

### DIFF
--- a/chartTypes/column/postprocessings.js
+++ b/chartTypes/column/postprocessings.js
@@ -3,5 +3,6 @@ const commonPostprocessings = require("../commonPostprocessings.js");
 module.exports = [
   commonPostprocessings.addPrognosisPattern,
   commonPostprocessings.hideRepeatingTickLabels,
-  commonPostprocessings.highlightZeroGridLineIfPositiveAndNegative
+  commonPostprocessings.highlightZeroGridLineIfPositiveAndNegative,
+  commonPostprocessings.showOnlyFirstAndLastLabel
 ];

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -120,9 +120,15 @@ function getColumnDateSeriesHandlingMappings() {
           objectPath.set(spec, "axes.0.encode.labels.update.text", {
             signal: `formatDateForInterval(datum.value, '${interval}')`
           });
-          objectPath.set(spec, "axes.0.labelBound", true);
-          objectPath.set(spec, "axes.0.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
-        }
+
+          // disable bound check and flush to zero 
+          // to show first and last labels that would otherwise will be out of bound
+          objectPath.set(spec, "axes.0.labelBound", false);
+          objectPath.set(spec, "axes.0.labelFlush", 0);
+          // originally use parity label overlap strategy if we have a date series
+          // but greedy solves the label problem on mobile
+          objectPath.set(spec, "axes.0.labelOverlap", "greedy"); 
+           }
       }
     }
   ];

--- a/chartTypes/commonMappings.js
+++ b/chartTypes/commonMappings.js
@@ -10,7 +10,7 @@ function getLineDateSeriesHandlingMappings() {
   return [
     {
       path: "item.data", // various settings that are not tied to an option
-      mapToSpec: function(itemData, spec, mappingData) {
+      mapToSpec: function (itemData, spec, mappingData) {
         const item = mappingData.item;
         if (
           (mappingData.dateFormat &&
@@ -22,23 +22,23 @@ function getLineDateSeriesHandlingMappings() {
           objectPath.set(spec, "scales.0.type", "time"); // time scale type: https://vega.github.io/vega/docs/scales/#time
           objectPath.set(spec, "axes.0.ticks", true); // show ticks if we have a date series
         }
-      }
+      },
     },
     {
       path: "item.options.dateSeriesOptions.interval",
-      mapToSpec: function(interval, spec, mappingData) {
+      mapToSpec: function (interval, spec, mappingData) {
         // only use this option if we have a valid dateFormat
         // if so, the scale type is set to time by now so we can check this
         if (spec.scales[0].type === "time") {
           objectPath.set(spec, "axes.0.encode.labels.update.text", {
-            signal: `formatDateForInterval(datum.value, '${interval}')`
+            signal: `formatDateForInterval(datum.value, '${interval}')`,
           });
         }
-      }
+      },
     },
     {
       path: "item.options.dateSeriesOptions.labels",
-      mapToSpec: function(labels, spec, mappingData) {
+      mapToSpec: function (labels, spec, mappingData) {
         if (!mappingData.dateFormat) {
           return;
         }
@@ -59,7 +59,7 @@ function getLineDateSeriesHandlingMappings() {
           // set the values explicitly to the first and last value
           objectPath.set(spec, "axes.0.values", [
             firstValue.valueOf(), // we need to set timestamps here because the values array doesn't like objects (Date)
-            lastValue.valueOf() // they will be sent through d3-time-format in the end, which recognises the timestamps and does the correct thing.
+            lastValue.valueOf(), // they will be sent through d3-time-format in the end, which recognises the timestamps and does the correct thing.
           ]);
 
           // setting labelBound to false is just for security, the following positioning logic should make sure the label never spans outside the axis
@@ -73,18 +73,18 @@ function getLineDateSeriesHandlingMappings() {
                 // &&
                 // valueLabelWidth / 2 > posOfTickValue - leftSideOfAxis (would the label span outside the axis on the left side)
                 test: `(datum.value - utcFormat(extent(domain('xScale'))[0], '%Q') < utcFormat(extent(domain('xScale'))[1], '%Q') - datum.value) && measureAxisLabelWidth(formatDateForInterval(datum.value, '${interval}')) / 2 > (scale('xScale', datum.value) - scale('xScale', extent(domain('xScale'))[0]))`,
-                value: "left"
+                value: "left",
               },
               {
                 // value - minValue > maxValue - value (is the value on the right side of the axis)
                 // &&
                 // valueLabelWidth / 2 > rightSideOfAxis - posOfTickValue (would the label span outside the axis on the right side)
                 test: `(datum.value - utcFormat(extent(domain('xScale'))[0], '%Q') > utcFormat(extent(domain('xScale'))[1], '%Q') - datum.value) && measureAxisLabelWidth(formatDateForInterval(datum.value, '${interval}')) / 2 > (scale('xScale', extent(domain('xScale'))[1]) - scale('xScale', datum.value))`,
-                value: "right"
+                value: "right",
               },
               {
-                value: "center"
-              }
+                value: "center",
+              },
             ]);
           }
         } else if (labels === "many" || !labels) {
@@ -96,7 +96,7 @@ function getLineDateSeriesHandlingMappings() {
               "axes.0.values",
               intervals[interval]
                 .ticks(mappingData.item.data)
-                .map(d => d.valueOf())
+                .map((d) => d.valueOf())
             );
           } else {
             objectPath.set(
@@ -106,8 +106,8 @@ function getLineDateSeriesHandlingMappings() {
             );
           }
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -115,22 +115,24 @@ function getColumnDateSeriesHandlingMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.interval",
-      mapToSpec: function(interval, spec, mappingData) {
+      mapToSpec: function (interval, spec, mappingData) {
         if (mappingData.dateFormat) {
           objectPath.set(spec, "axes.0.encode.labels.update.text", {
-            signal: `formatDateForInterval(datum.value, '${interval}')`
+            signal: `formatDateForInterval(datum.value, '${interval}')`,
           });
 
-          // disable bound check and flush to zero 
-          // to show first and last labels that would otherwise will be out of bound
-          objectPath.set(spec, "axes.0.labelBound", false);
+          objectPath.set(spec, "axes.0.labelBound", true);
           objectPath.set(spec, "axes.0.labelFlush", 0);
-          // originally use parity label overlap strategy if we have a date series
-          // but greedy solves the label problem on mobile
-          objectPath.set(spec, "axes.0.labelOverlap", "greedy"); 
-           }
-      }
-    }
+          // if we are width mobile width, we disable overlap control and hide the unnecessary ones in postprocessing
+          // otherwise we use parity
+          if (mappingData.width < 400) {
+            objectPath.set(spec, "axes.0.labelOverlap", false);
+          } else {
+            objectPath.set(spec, "axes.0.labelOverlap", "parity");
+          }
+        }
+      },
+    },
   ];
 }
 
@@ -138,16 +140,16 @@ function getBarDateSeriesHandlingMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.interval",
-      mapToSpec: function(interval, spec, mappingData) {
+      mapToSpec: function (interval, spec, mappingData) {
         if (mappingData.dateFormat) {
           objectPath.set(spec, "axes.1.encode.labels.update.text", {
-            signal: `formatDateForInterval(datum.value, '${interval}')`
+            signal: `formatDateForInterval(datum.value, '${interval}')`,
           });
           objectPath.set(spec, "axes.1.labelBound", true);
           objectPath.set(spec, "axes.1.labelOverlap", "parity"); // use parity label overlap strategy if we have a date series
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -155,7 +157,7 @@ function getColumnAreaPrognosisMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, mappingData, id) {
+      mapToSpec: function (prognosisStart, spec, mappingData, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -165,7 +167,7 @@ function getColumnAreaPrognosisMappings() {
           value: dateSeries.getPrognosisStartDate(
             mappingData.originalItemData,
             prognosisStart
-          )
+          ),
         });
 
         // add the data for prognosis
@@ -175,9 +177,9 @@ function getColumnAreaPrognosisMappings() {
           transform: [
             {
               type: "filter",
-              expr: "datum.xValue >= prognosisStartDate"
-            }
-          ]
+              expr: "datum.xValue >= prognosisStartDate",
+            },
+          ],
         });
 
         const prognosisMarks = clone(spec.marks[0]);
@@ -189,17 +191,17 @@ function getColumnAreaPrognosisMappings() {
         }
         if (prognosisMarks.marks) {
           prognosisMarks.marks[0].encode.enter.fill = {
-            value: `url(#prognosisPattern${id})`
+            value: `url(#prognosisPattern${id})`,
           };
         } else {
           prognosisMarks.encode.enter.fill = {
-            value: `url(#prognosisPattern${id})`
+            value: `url(#prognosisPattern${id})`,
           };
         }
 
         objectPath.push(spec, "marks", prognosisMarks);
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -207,7 +209,7 @@ function getBarPrognosisMappings() {
   return [
     {
       path: "item.options.dateSeriesOptions.prognosisStart",
-      mapToSpec: function(prognosisStart, spec, mappingData, id) {
+      mapToSpec: function (prognosisStart, spec, mappingData, id) {
         if (!Number.isInteger(prognosisStart)) {
           return;
         }
@@ -217,7 +219,7 @@ function getBarPrognosisMappings() {
           value: dateSeries.getPrognosisStartDate(
             mappingData.originalItemData,
             prognosisStart
-          )
+          ),
         });
 
         // add the data for prognosis
@@ -227,9 +229,9 @@ function getBarPrognosisMappings() {
           transform: [
             {
               type: "filter",
-              expr: "datum.xValue >= prognosisStartDate"
-            }
-          ]
+              expr: "datum.xValue >= prognosisStartDate",
+            },
+          ],
         });
 
         const prognosisMarks = clone(spec.marks[0]);
@@ -237,19 +239,19 @@ function getBarPrognosisMappings() {
         prognosisMarks.from.facet.data = "prognosis";
 
         prognosisMarks.marks[0].marks[0].encode.enter.fill = {
-          value: `url(#prognosisPattern${id})`
+          value: `url(#prognosisPattern${id})`,
         };
 
         // take only the first rect mark
         prognosisMarks.marks[0].marks = [
-          prognosisMarks.marks[0].marks.find(mark => mark.type === "rect")
+          prognosisMarks.marks[0].marks.find((mark) => mark.type === "rect"),
         ];
 
         prognosisMarks.marks[0].marks[0].name = "prognosisBar";
 
         spec.marks.push(prognosisMarks);
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -257,7 +259,7 @@ function getColumnLabelColorMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function (itemData, spec) {
         if (!spec.config.axis.labelColorDark) {
           return;
         }
@@ -266,8 +268,8 @@ function getColumnLabelColorMappings() {
           "axes.0.encode.labels.update.fill.value",
           spec.config.axis.labelColorDark
         ); // use the dark color for categorical bar/column labels
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -275,7 +277,7 @@ function getBarLabelColorMappings() {
   return [
     {
       path: "data",
-      mapToSpec: function(itemData, spec) {
+      mapToSpec: function (itemData, spec) {
         if (!spec.config.axis.labelColorDark) {
           return;
         }
@@ -284,8 +286,8 @@ function getBarLabelColorMappings() {
           "axes.1.encode.labels.update.fill.value",
           spec.config.axis.labelColorDark
         ); // use the dark color for categorical bar/column labels
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -293,7 +295,7 @@ function getHeightMappings() {
   return [
     {
       path: "toolRuntimeConfig.displayOptions.size",
-      mapToSpec: function(size, spec, mappingData) {
+      mapToSpec: function (size, spec, mappingData) {
         let aspectRatio;
         if (size === "prominent") {
           aspectRatio = 9 / 16;
@@ -315,8 +317,8 @@ function getHeightMappings() {
           height = height + 20;
         }
         objectPath.set(spec, "height", height);
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -324,22 +326,22 @@ function getHighlightRowsMapping() {
   return [
     {
       path: "item.options.highlightDataRows",
-      mapToSpec: function(highlightDataRows, spec) {
+      mapToSpec: function (highlightDataRows, spec) {
         if (
           !Array.isArray(highlightDataRows) ||
           highlightDataRows.length === 0
         ) {
           return;
         }
-        spec.data[0].values.map(value => {
+        spec.data[0].values.map((value) => {
           if (highlightDataRows.includes(value.xIndex)) {
             value.isHighlighted = true;
           } else {
             value.isHighlighted = false;
           }
         });
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -347,14 +349,14 @@ function getHighlightSeriesMapping() {
   return [
     {
       path: "item.options.highlightDataSeries",
-      mapToSpec: function(highlightDataSeries, spec) {
+      mapToSpec: function (highlightDataSeries, spec) {
         if (
           !Array.isArray(highlightDataSeries) ||
           highlightDataSeries.length === 0
         ) {
           return;
         }
-        spec.data[0].values.map(value => {
+        spec.data[0].values.map((value) => {
           // if isHighlighted is already set to false, we return here
           // highlight rows and highlight columns are in an AND relationship to result in a highlighted column
           if (value.isHighlighted === false) {
@@ -366,8 +368,8 @@ function getHighlightSeriesMapping() {
             value.isHighlighted = false;
           }
         });
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -375,7 +377,7 @@ function getColorOverwritesRowsMappings() {
   return [
     {
       path: "item.options.colorOverwritesRows",
-      mapToSpec: function(colorOverwritesRows, spec, mappingData) {
+      mapToSpec: function (colorOverwritesRows, spec, mappingData) {
         // do not handle colorOverwriteRows if we have more than two dataseries.
         if (mappingData.item.data[0].length > 3) {
           return;
@@ -385,7 +387,7 @@ function getColorOverwritesRowsMappings() {
           if (!colorOverwrite.color || Number.isNaN(colorOverwrite.position)) {
             continue;
           }
-          spec.data[0].values.map(value => {
+          spec.data[0].values.map((value) => {
             if (value.xIndex === colorOverwrite.position - 1) {
               value.color = colorOverwrite.color;
               if (colorOverwrite.colorLight) {
@@ -394,8 +396,8 @@ function getColorOverwritesRowsMappings() {
             }
           });
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -403,7 +405,7 @@ function getColumnAxisPositioningMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(data, spec, mappingData) {
+      mapToSpec: function (data, spec, mappingData) {
         // if we have positive and negative values, we want a 0 baseline to be included
         const max = dataHelpers.getMaxValue(data);
 
@@ -423,8 +425,8 @@ function getColumnAxisPositioningMappings() {
             objectPath.set(spec, "axes.0.encode.title.update.y.value", -30);
           }
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -432,7 +434,7 @@ function getBarAxisPositioningMappings() {
   return [
     {
       path: "item.data",
-      mapToSpec: function(data, spec, mappingData) {
+      mapToSpec: function (data, spec, mappingData) {
         // if we have positive and negative values, we want a 0 baseline to be included
         const max = dataHelpers.getMaxValue(data);
 
@@ -450,8 +452,8 @@ function getBarAxisPositioningMappings() {
             );
           }
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -459,7 +461,7 @@ function getColumnEventsMapping() {
   return [
     {
       path: "item.events",
-      mapToSpec: function(events, spec, mappingData) {
+      mapToSpec: function (events, spec, mappingData) {
         const { item } = mappingData;
         const config = spec.config.events;
 
@@ -472,8 +474,8 @@ function getColumnEventsMapping() {
           // Event annotations go in front of areas/lines
           spec.marks.push(...verticalMarks);
         }
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -481,15 +483,15 @@ function getBarEventsMapping() {
   return [
     {
       path: "item.events",
-      mapToSpec: function(events, spec, mappingData) {
+      mapToSpec: function (events, spec, mappingData) {
         const config = spec.config.events;
 
         spec.data.push(...eventHelpers.vegaSpecData(events));
         const horizontalMarks = eventHelpers.horizontalMarks(config);
         // Event annotations go behind bars
         spec.marks.unshift(...horizontalMarks);
-      }
-    }
+      },
+    },
   ];
 }
 
@@ -508,5 +510,5 @@ module.exports = {
   getColumnAxisPositioningMappings,
   getBarAxisPositioningMappings,
   getColumnEventsMapping,
-  getBarEventsMapping
+  getBarEventsMapping,
 };

--- a/chartTypes/commonPostprocessings.js
+++ b/chartTypes/commonPostprocessings.js
@@ -5,7 +5,7 @@ const { modifyColorStoke } = require("../helpers/elementModify.js");
 const d3config = require("../config/d3.js");
 
 const hideRepeatingTickLabels = {
-  process: function(svg, spec, item, toolRuntimeConfig) {
+  process: function (svg, spec, item, toolRuntimeConfig) {
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
 
@@ -13,7 +13,7 @@ const hideRepeatingTickLabels = {
     for (const labelGroup of labelGroups) {
       const visibleTextNodes = Array.prototype.slice
         .call(labelGroup.querySelectorAll("text"))
-        .filter(textNode => {
+        .filter((textNode) => {
           return textNode.getAttribute("style").includes("opacity: 1");
         });
       // loop over all the visible textNodes, if the text is the same as the one before, hide it
@@ -27,11 +27,11 @@ const hideRepeatingTickLabels = {
       }
     }
     return document.body.innerHTML;
-  }
+  },
 };
 
 const hideRepeatingBarTopLabels = {
-  process: function(svg, spec, item, toolRuntimeConfig) {
+  process: function (svg, spec, item, toolRuntimeConfig) {
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
 
@@ -46,11 +46,11 @@ const hideRepeatingBarTopLabels = {
       }
     }
     return document.body.innerHTML;
-  }
+  },
 };
 
 const hideTicksWithoutLabels = {
-  process: function(svg, spec, item, toolRuntimeConfig) {
+  process: function (svg, spec, item, toolRuntimeConfig) {
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
 
@@ -78,20 +78,22 @@ const hideTicksWithoutLabels = {
     }
 
     for (let hiddenLabelIndex of hiddenLabelsIndexes) {
-      tickNodes.item(hiddenLabelIndex).setAttribute(
-        "style",
-        tickNodes
-          .item(hiddenLabelIndex)
-          .getAttribute("style")
-          .replace(`opacity: 1`, `opacity: 0`)
-      );
+      tickNodes
+        .item(hiddenLabelIndex)
+        .setAttribute(
+          "style",
+          tickNodes
+            .item(hiddenLabelIndex)
+            .getAttribute("style")
+            .replace(`opacity: 1`, `opacity: 0`)
+        );
     }
     return document.body.innerHTML;
-  }
+  },
 };
 
 const addPrognosisPattern = {
-  process: function(svg, spec, item, toolRuntimeConfig, id) {
+  process: function (svg, spec, item, toolRuntimeConfig, id) {
     if (
       !item.options.dateSeriesOptions ||
       !Number.isInteger(item.options.dateSeriesOptions.prognosisStart)
@@ -112,11 +114,11 @@ const addPrognosisPattern = {
     document.querySelector("svg").appendChild(patternElement);
 
     return document.body.innerHTML;
-  }
+  },
 };
 
 const highlightZeroGridLineIfPositiveAndNegative = {
-  process: function(svg, spec, item, toolRuntimeConfig, id) {
+  process: function (svg, spec, item, toolRuntimeConfig, id) {
     // return early if there are only positive values
     if (
       dataHelpers.getMinValue(item.data) >= 0 &&
@@ -139,7 +141,7 @@ const highlightZeroGridLineIfPositiveAndNegative = {
     // we determine this by the domain value property for the y axes
     let axisIndex;
     if (
-      spec.scales.find(scale => scale.name === "yScale").domain.field ===
+      spec.scales.find((scale) => scale.name === "yScale").domain.field ===
       "yValue"
     ) {
       axisIndex = 1;
@@ -186,11 +188,11 @@ const highlightZeroGridLineIfPositiveAndNegative = {
     }
 
     return document.body.innerHTML;
-  }
+  },
 };
 
 const addOutlineToAnnotationLabels = {
-  process: function(svg, spec, item, toolRuntimeConfig) {
+  process: function (svg, spec, item, toolRuntimeConfig) {
     // this duplicates the text nodes to have a white outline around the text
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
@@ -214,7 +216,35 @@ const addOutlineToAnnotationLabels = {
       textNode.parentNode.appendChild(textNode);
     }
     return document.body.innerHTML;
-  }
+  },
+};
+
+const showOnlyFirstAndLastLabel = {
+  process: function (svg, spec, item, toolRuntimeConfig) {
+    const svgDom = new JSDOM(svg);
+    const document = svgDom.window.document;
+
+    // this function only need to run if we are on mobile
+    if (spec.width > 400) return document.body.innerHTML;
+    console.log(item);
+    const allLabelGroups = document.querySelectorAll(".role-axis-label");
+    // only target x labels
+    const xLabels = allLabelGroups.length > 0 ? allLabelGroups[0] : [];
+    const visibleTextNodes = Array.prototype.slice
+      .call(xLabels.querySelectorAll("text"))
+      .filter((textNode) => {
+        return textNode.getAttribute("style").includes("opacity: 1");
+      });
+    // 4 label should still be visible
+    if (visibleTextNodes.length > 4) {
+      // we set opacity to zero for all inbetween nodes, leaving the first and last visible
+      for (let i = 1; i < visibleTextNodes.length - 1; i++) {
+        visibleTextNodes[i].style.opacity = "0";
+      }
+    }
+
+    return document.body.innerHTML;
+  },
 };
 
 module.exports = {
@@ -222,6 +252,8 @@ module.exports = {
   hideRepeatingBarTopLabels: hideRepeatingBarTopLabels,
   hideTicksWithoutLabels: hideTicksWithoutLabels,
   addPrognosisPattern: addPrognosisPattern,
-  highlightZeroGridLineIfPositiveAndNegative: highlightZeroGridLineIfPositiveAndNegative,
-  addOutlineToAnnotationLabels: addOutlineToAnnotationLabels
+  highlightZeroGridLineIfPositiveAndNegative:
+    highlightZeroGridLineIfPositiveAndNegative,
+  addOutlineToAnnotationLabels: addOutlineToAnnotationLabels,
+  showOnlyFirstAndLastLabel: showOnlyFirstAndLastLabel,
 };

--- a/chartTypes/commonPostprocessings.js
+++ b/chartTypes/commonPostprocessings.js
@@ -226,7 +226,7 @@ const showOnlyFirstAndLastLabel = {
 
     // this function only need to run if we are on mobile
     if (spec.width > 400) return document.body.innerHTML;
-    console.log(item);
+    
     const allLabelGroups = document.querySelectorAll(".role-axis-label");
     // only target x labels
     const xLabels = allLabelGroups.length > 0 ? allLabelGroups[0] : [];

--- a/chartTypes/commonPostprocessings.js
+++ b/chartTypes/commonPostprocessings.js
@@ -223,10 +223,11 @@ const showOnlyFirstAndLastLabel = {
   process: function (svg, spec, item, toolRuntimeConfig) {
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
+    const isDate = item.data[1] && item.data[1][0] && item.data[1][0].getMonth !== undefined | false;
 
     // this function only need to run if we are on mobile
-    if (spec.width > 400) return document.body.innerHTML;
-    
+    if (spec.width > 400 || !isDate) return document.body.innerHTML;
+
     const allLabelGroups = document.querySelectorAll(".role-axis-label");
     // only target x labels
     const xLabels = allLabelGroups.length > 0 ? allLabelGroups[0] : [];

--- a/resources/fixtures/data/bar-axislabel-overlap.json
+++ b/resources/fixtures/data/bar-axislabel-overlap.json
@@ -1,0 +1,80 @@
+{
+  "title": "FIXTURE: Bar - axislabel overlap",
+  "subtitle": "Labels",
+  "data": [
+    [
+      "Datum",
+      "Anzahl"
+    ],
+    [
+      "2021-03-08",
+      "1207"
+    ],
+    [
+      "2021-03-15",
+      "1290"
+    ],
+    [
+      "2021-03-22",
+      "6731"
+    ],
+    [
+      "2021-03-29",
+      "1996"
+    ],
+    [
+      "2021-04-05",
+      "1231"
+    ],
+    [
+      "2021-04-12",
+      "11920"
+    ],
+    [
+      "2021-04-19",
+      "9877"
+    ],
+    [
+      "2021-04-26",
+      "10264"
+    ],
+    [
+      "2021-05-03",
+      "6335"
+    ],
+    [
+      "2021-05-10",
+      "5046"
+    ],
+    [
+      "2021-05-17",
+      "3880"
+    ],
+    [
+      "2021-05-24",
+      "3115"
+    ],
+    [
+      "2021-06-02",
+      "1197"
+    ]
+  ],
+  "options": {
+    "chartType": "Bar",
+    "hideAxisLabel": false,
+    "highlightDataSeries": [],
+    "highlightDataRows": [],
+    "annotations": {},
+    "barOptions": {
+      "isBarChart": false,
+      "forceBarsOnSmall": false
+    },
+    "dateSeriesOptions": {
+      "interval": "auto",
+      "labels": "few",
+      "prognosisStart": null
+    },
+    "colorOverwritesSeries": [],
+    "colorOverwritesRows": []
+  }
+}

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -21,6 +21,7 @@ const fixtureData = [
   require(`${fixtureDataDirectory}/bar-large-numbers-auto.json`),
   require(`${fixtureDataDirectory}/bar-large-numbers-divide-by-1.json`),
   require(`${fixtureDataDirectory}/bar-maxValue.json`),
+  require(`${fixtureDataDirectory}/bar-axislabel-overlap.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-negative-only.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-negative.json`),
   require(`${fixtureDataDirectory}/bar-qualitative-single-serie.json`),


### PR DESCRIPTION
Addresses the following issue: 
https://3.basecamp.com/3500782/buckets/1333707/todos/3860502110

The good in this solution is that it is only uses Vega expression and should only target date series in column charts (which is the issue about).
I figured out that the combination of no bound, zero flush and greedy overlap will solve the issue, although the first and last labels are reaching out of bound of axis, yet they still remain visible in the chart frame. 

The ideal solution could be aligning them to the respective axis edges,  but after trying out some methods I arrived to the conclusion that a more precise solution would take a disproportionate amount of time and energy. 

Testen on some charts on staging.
Fixture of the original issue chart included.
