### PR TITLE
(line) Set interpolate property on both marks

### DIFF
--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -229,6 +229,11 @@ module.exports = function getMappings() {
             "marks.0.marks.0.encode.enter.interpolate.value",
             interpolation
           );
+          objectPath.set(
+            spec,
+            "marks.0.marks.1.encode.enter.interpolate.value",
+            interpolation
+          );
         }
       },
     },

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -137,10 +137,7 @@
                   "test": "datum.isHighlighted === true",
                   "value": "white"
                 }
-              ],
-              "interpolate": {
-                "value": "linear"
-              }
+              ]
             }
           }
         },


### PR DESCRIPTION
This PR resolves this issue: https://3.basecamp.com/3500782/buckets/1333707/todos/4124664332

In https://github.com/nzzdev/Q-chart/pull/231 the visibility of highlighted lines where improved by adding a white border. This is achieved by drawing two lines on top of each other. One a bit thinker with white color and another a bit thinner with the line color. 

In that PR it was forgotten to adjust the lineInterpolation option to update both lines with the given interpolation. This PR fixes this issue.

This PR can be tested by checking [this graphic](https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d596160) on test environment. [The same graphic](https://q.st-staging.nzz.ch/item/e9046b127bd99afc9cd208b94d592f25) is also on staging environment, where the lineInterpolation is not working.