### PR TITLE
Release v3.6.11

### DIFF
--- a/chartTypes/line/mapping.js
+++ b/chartTypes/line/mapping.js
@@ -229,6 +229,11 @@ module.exports = function getMappings() {
             "marks.0.marks.0.encode.enter.interpolate.value",
             interpolation
           );
+          objectPath.set(
+            spec,
+            "marks.0.marks.1.encode.enter.interpolate.value",
+            interpolation
+          );
         }
       },
     },

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -137,10 +137,7 @@
                   "test": "datum.isHighlighted === true",
                   "value": "white"
                 }
-              ],
-              "interpolate": {
-                "value": "linear"
-              }
+              ]
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- (line) Fixes `interpolateLine` property (see https://github.com/nzzdev/Q-chart/pull/237)