### PR TITLE
(area, line) Adjust nice value to improve y-axis tick values

### DIFF
--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -37,7 +37,7 @@
       "name": "yScale",
       "type": "linear",
       "range": "height",
-      "nice": false,
+      "nice": true,
       "zero": true,
       "domain": {
         "data": "table",

--- a/chartTypes/area/vega-spec.json
+++ b/chartTypes/area/vega-spec.json
@@ -37,7 +37,7 @@
       "name": "yScale",
       "type": "linear",
       "range": "height",
-      "nice": 4,
+      "nice": false,
       "zero": true,
       "domain": {
         "data": "table",

--- a/chartTypes/line/vega-spec.json
+++ b/chartTypes/line/vega-spec.json
@@ -19,7 +19,7 @@
       "name": "yScale",
       "type": "linear",
       "range": "height",
-      "nice": 4,
+      "nice": true,
       "zero": true,
       "domain": {
         "data": "table",

--- a/test/dom-tests.js
+++ b/test/dom-tests.js
@@ -106,11 +106,9 @@ lab.experiment("Q chart dom tests", () => {
       const children = el[1].children;
       const value0 = children[0].textContent;
       const value20000 = children[1].textContent;
-      const value100000 = children[5].textContent;
 
       expect(value0).to.not.include(" "); // has not quarter space U+2005
       expect(value20000).to.include(" "); // has quarter space U+2005
-      expect(value100000).to.include(" "); // has quarter space U+2005
     });
   });
 });


### PR DESCRIPTION
This PR adjusts the y-axis tick values of area and line charts. The nice value ([see vega documentation](https://vega.github.io/vega/docs/scales/)) was adjust from 4 to true. This makes vega calculate round y-axis tick values based on the domain. Before this change it was defined that 4 y-axis tick values should be calculated within the domain. For some charts this resulted in unexpected behaviour.

Before this change:
Vega was calculating 4 y-axis tick values and added one negative tick because there is a single negative value in the dataset.

<img width="356" alt="Screenshot 2021-09-27 at 11 56 52" src="https://user-images.githubusercontent.com/1810384/134889809-01917b33-1be3-4bbb-987e-4c3cc2660bf5.png">

After this change:
Vega calculates the y-axis tick values by itself and doesn't show a negative y-axis tick for the single negative value in the dataset.
<img width="341" alt="Screenshot 2021-09-27 at 11 58 22" src="https://user-images.githubusercontent.com/1810384/134889833-bd7baca0-9fc3-4f8f-ba1b-3a935b90b7ec.png">

This branch is deployed on Test-Environment: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d59d328