### PR TITLE
(bar-stacked) Align valuesOnBars to the end of the bar

### DIFF
--- a/chartTypes/bar-stacked/mapping.js
+++ b/chartTypes/bar-stacked/mapping.js
@@ -11,8 +11,8 @@ const intervals = require("../../helpers/dateSeries.js").intervals;
 
 const commonMappings = require("../commonMappings.js");
 
-const getLongestDataLabel = require("../../helpers/data.js")
-  .getLongestDataLabel;
+const getLongestDataLabel =
+  require("../../helpers/data.js").getLongestDataLabel;
 const textMeasure = require("../../helpers/textMeasure.js");
 
 function shouldHaveLabelsOnTopOfBar(mappingData) {
@@ -239,40 +239,40 @@ module.exports = function getMapping() {
               x: [
                 {
                   test: tests.positiveValue,
-                  field: "x",
-                },
-                {
-                  test: tests.negativeValue,
                   field: "x2",
                 },
                 {
+                  test: tests.negativeValue,
                   field: "x",
+                },
+                {
+                  field: "x2",
                 },
               ],
               align: [
                 {
                   test: tests.positiveValue,
-                  value: "left",
-                },
-                {
-                  test: tests.negativeValue,
                   value: "right",
                 },
                 {
+                  test: tests.negativeValue,
                   value: "left",
+                },
+                {
+                  value: "right",
                 },
               ],
               dx: [
                 {
                   test: tests.positiveValue,
-                  value: valuePadding,
-                },
-                {
-                  test: tests.negativeValue,
                   value: -valuePadding,
                 },
                 {
+                  test: tests.negativeValue,
                   value: valuePadding,
+                },
+                {
+                  value: -valuePadding,
                 },
               ],
               fill: [


### PR DESCRIPTION
This PR changes the alignment of valuesOnBars on stacked bar charts to the end of the bar.

Before:
<img width="341" alt="Screenshot 2021-09-24 at 17 28 00" src="https://user-images.githubusercontent.com/1810384/134701003-fd1f6911-a611-4915-bcf1-c75dbfbc19f0.png">

After:
<img width="346" alt="Screenshot 2021-09-24 at 17 27 48" src="https://user-images.githubusercontent.com/1810384/134701030-41323765-ee7c-45db-9926-19db2a3445c9.png">

This branch is deployed on test environment: https://q.st-test.nzz.ch/item/e9046b127bd99afc9cd208b94d5aa445

See also [this Basecamp-ToDo](https://3.basecamp.com/3500782/buckets/1333707/todos/4199212117) where the discussion on the position of the values is documented. We are intending to try this out and if we find problems with it plan a project where we try to find a better solution for it.

