### PR TITLE
Release v3.7.1

### DIFF
--- a/chartTypes/commonPostprocessings.js
+++ b/chartTypes/commonPostprocessings.js
@@ -14,7 +14,7 @@ const hideRepeatingTickLabels = {
       const visibleTextNodes = Array.prototype.slice
         .call(labelGroup.querySelectorAll("text"))
         .filter((textNode) => {
-          return textNode.getAttribute("style").includes("opacity: 1");
+          return textNode.getAttribute("opacity") === "1";
         });
       // loop over all the visible textNodes, if the text is the same as the one before, hide it
       // start with the 2nd textNode
@@ -22,7 +22,7 @@ const hideRepeatingTickLabels = {
         if (
           visibleTextNodes[i].innerHTML === visibleTextNodes[i - 1].innerHTML
         ) {
-          visibleTextNodes[i].style.opacity = "0";
+          visibleTextNodes[i].setAttribute("opacity", "0");
         }
       }
     }
@@ -42,7 +42,7 @@ const hideRepeatingBarTopLabels = {
       if (
         barTopLabels.item(i).innerHTML === barTopLabels.item(i - 1).innerHTML
       ) {
-        barTopLabels.item(i).style.opacity = "0";
+        barTopLabels.item(i).setAttribute("opacity", "0");
       }
     }
     return document.body.innerHTML;
@@ -67,7 +67,7 @@ const hideTicksWithoutLabels = {
     for (let i = 0; i < textNodes.length; i++) {
       const textNode = textNodes.item(i);
       // if the textNode is visible
-      if (!textNode.getAttribute("style").includes("opacity: 1")) {
+      if (textNode.getAttribute("opacity") === "0") {
         hiddenLabelsIndexes.push(i);
       }
     }
@@ -78,15 +78,7 @@ const hideTicksWithoutLabels = {
     }
 
     for (let hiddenLabelIndex of hiddenLabelsIndexes) {
-      tickNodes
-        .item(hiddenLabelIndex)
-        .setAttribute(
-          "style",
-          tickNodes
-            .item(hiddenLabelIndex)
-            .getAttribute("style")
-            .replace(`opacity: 1`, `opacity: 0`)
-        );
+      tickNodes.item(hiddenLabelIndex).setAttribute("opacity", "0");
     }
     return document.body.innerHTML;
   },
@@ -173,7 +165,6 @@ const highlightZeroGridLineIfPositiveAndNegative = {
         zeroTickIndex,
         ".role-axis-grid",
         "line",
-        toolRuntimeConfig.axis.tickColor,
         toolRuntimeConfig.axis.labelColor
       );
 
@@ -182,7 +173,6 @@ const highlightZeroGridLineIfPositiveAndNegative = {
         zeroTickIndex,
         ".role-axis-tick",
         "line",
-        toolRuntimeConfig.axis.tickColor,
         toolRuntimeConfig.axis.labelColor
       );
     }
@@ -200,18 +190,9 @@ const addOutlineToAnnotationLabels = {
     const annotationLabels = document.querySelectorAll(".annotation-label");
     for (const label of annotationLabels) {
       const textNode = label.querySelector("text");
-
-      // once this is supported by more browsers or we do not have to support them anymore,
-      // we can use paint-order here. for now we just clone the textNode and use stroke instead of fill on the clone
-      // textNode.setAttribute("paint-order", "stroke");
-
-      const cloneTextNode = textNode.cloneNode(true);
-      cloneTextNode.setAttribute("fill", "currentColor");
-      cloneTextNode.setAttribute("stroke", "currentColor");
-      cloneTextNode.setAttribute("stroke-width", "3px");
-
-      textNode.parentNode.appendChild(cloneTextNode);
-
+      textNode.setAttribute("stroke", "currentColor");
+      textNode.setAttribute("stroke-width", "3px");
+      textNode.setAttribute("paint-order", "stroke");
       // move the textNode to the end
       textNode.parentNode.appendChild(textNode);
     }
@@ -223,7 +204,10 @@ const showOnlyFirstAndLastLabel = {
   process: function (svg, spec, item, toolRuntimeConfig) {
     const svgDom = new JSDOM(svg);
     const document = svgDom.window.document;
-    const isDate = item.data[1] && item.data[1][0] && item.data[1][0].getMonth !== undefined | false;
+    const isDate =
+      item.data[1] &&
+      item.data[1][0] &&
+      (item.data[1][0].getMonth !== undefined) | false;
 
     // this function only need to run if we are on mobile
     if (spec.width > 400 || !isDate) return document.body.innerHTML;
@@ -234,13 +218,13 @@ const showOnlyFirstAndLastLabel = {
     const visibleTextNodes = Array.prototype.slice
       .call(xLabels.querySelectorAll("text"))
       .filter((textNode) => {
-        return textNode.getAttribute("style").includes("opacity: 1");
+        return textNode.getAttribute("opacity") === "1";
       });
     // 4 label should still be visible
     if (visibleTextNodes.length > 4) {
       // we set opacity to zero for all inbetween nodes, leaving the first and last visible
       for (let i = 1; i < visibleTextNodes.length - 1; i++) {
-        visibleTextNodes[i].style.opacity = "0";
+        visibleTextNodes[i].setAttribute("opacity", "0");
       }
     }
 

--- a/helpers/elementModify.js
+++ b/helpers/elementModify.js
@@ -3,26 +3,16 @@ function modifyColorStoke(
   zeroTickIndex,
   elemClass,
   svgElem,
-  replaceColor,
-  targetColor
+  color
 ) {
-  const axisElement = axisElements
-    .querySelector(elemClass);
+  const axisElement = axisElements.querySelector(elemClass);
 
   if (!axisElement) {
     return;
   }
 
   const element = axisElement.querySelectorAll(svgElem);
-  element
-    .item(zeroTickIndex)
-    .setAttribute(
-      "style",
-      element
-        .item(zeroTickIndex)
-        .getAttribute("style")
-        .replace(`stroke: ${replaceColor}`, `stroke: ${targetColor}`)
-    );
+  element.item(zeroTickIndex).setAttribute("stroke", color);
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -745,6 +745,11 @@
       "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
       "dev": true
     },
+    "@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
     "@types/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
@@ -1356,9 +1361,9 @@
       "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
     },
     "d3-dsv": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
       "requires": {
         "commander": "2",
         "iconv-lite": "0.4",
@@ -1388,28 +1393,21 @@
       "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-geo": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
-      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
       "requires": {
-        "d3-array": "1"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-        }
+        "d3-array": "^2.5.0"
       }
     },
     "d3-geo-projection": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
-      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
+      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
       "requires": {
         "commander": "2",
-        "d3-array": "1",
-        "d3-geo": "^1.12.0",
+        "d3-array": "1 - 2",
+        "d3-geo": "1.12.0 - 2",
         "resolve": "^1.1.10"
       },
       "dependencies": {
@@ -1417,18 +1415,13 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "d3-array": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
         }
       }
     },
     "d3-hierarchy": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
     },
     "d3-interpolate": {
       "version": "2.0.1",
@@ -1439,9 +1432,9 @@
       }
     },
     "d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
     },
     "d3-quadtree": {
       "version": "2.0.0",
@@ -1471,11 +1464,11 @@
       }
     },
     "d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
       "requires": {
-        "d3-path": "1"
+        "d3-path": "1 - 2"
       }
     },
     "d3-time": {
@@ -3652,35 +3645,37 @@
       "dev": true
     },
     "vega": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.9.1.tgz",
-      "integrity": "sha512-Wd5WAfaXPGuHk5cSFqiFNkkw5DXRSZcl+q4x351VUbmV5/IRipyGZx05EbBP5D9B40Xb/Tt2I+JQBBdxuYYIxQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.21.0.tgz",
+      "integrity": "sha512-yqqRa9nAqYoAxe7sVhRpsh0b001fly7Yx05klPkXmrvzjxXd07gClW1mOuGgSnVQqo7jTp/LYgbO1bD37FbEig==",
       "requires": {
-        "vega-crossfilter": "4.0.1",
-        "vega-dataflow": "5.5.0",
-        "vega-encode": "4.5.2",
-        "vega-event-selector": "2.0.2",
-        "vega-expression": "2.6.3",
-        "vega-force": "4.0.3",
-        "vega-functions": "5.5.1",
-        "vega-geo": "4.3.0",
-        "vega-hierarchy": "4.0.3",
-        "vega-loader": "4.1.3",
-        "vega-parser": "5.12.0",
-        "vega-projection": "1.4.0",
-        "vega-regression": "1.0.4",
-        "vega-runtime": "5.0.2",
-        "vega-scale": "6.0.0",
-        "vega-scenegraph": "4.5.0",
-        "vega-statistics": "1.7.2",
-        "vega-time": "1.0.0",
-        "vega-transforms": "4.6.0",
-        "vega-typings": "0.12.0",
-        "vega-util": "1.12.2",
-        "vega-view": "5.4.0",
-        "vega-view-transforms": "4.5.0",
-        "vega-voronoi": "4.1.1",
-        "vega-wordcloud": "4.0.4"
+        "vega-crossfilter": "~4.0.5",
+        "vega-dataflow": "~5.7.4",
+        "vega-encode": "~4.8.3",
+        "vega-event-selector": "~3.0.0",
+        "vega-expression": "~5.0.0",
+        "vega-force": "~4.0.7",
+        "vega-format": "~1.0.4",
+        "vega-functions": "~5.12.1",
+        "vega-geo": "~4.3.8",
+        "vega-hierarchy": "~4.0.9",
+        "vega-label": "~1.1.0",
+        "vega-loader": "~4.4.1",
+        "vega-parser": "~6.1.4",
+        "vega-projection": "~1.4.5",
+        "vega-regression": "~1.0.9",
+        "vega-runtime": "~6.1.3",
+        "vega-scale": "~7.1.1",
+        "vega-scenegraph": "~4.9.4",
+        "vega-statistics": "~1.7.10",
+        "vega-time": "~2.0.4",
+        "vega-transforms": "~4.9.4",
+        "vega-typings": "~0.22.0",
+        "vega-util": "~1.17.0",
+        "vega-view": "~5.10.1",
+        "vega-view-transforms": "~4.5.8",
+        "vega-voronoi": "~4.1.5",
+        "vega-wordcloud": "~4.1.3"
       }
     },
     "vega-canvas": {
@@ -3689,346 +3684,329 @@
       "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
     },
     "vega-crossfilter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.1.tgz",
-      "integrity": "sha512-wLNS4JzKaOLj8EAzI/v8XBJjUWMRWYSu6EeQF4o9Opq/78u87Ol9Lc5I27UHsww5dNNH/tHubAV4QPIXnGOp5Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
+      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
       "requires": {
-        "d3-array": "^2.0.3",
-        "vega-dataflow": "^5.1.0",
-        "vega-util": "^1.8.0"
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-dataflow": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.5.0.tgz",
-      "integrity": "sha512-9eRe2qLpwvEegBoSaH3vdziSLMZSszY02wxVmvcFzHe57Rf/eYEr0YRuW4qc+gMmwURPYu9wtmeUTiK4XhDKXw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
+      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
       "requires": {
-        "vega-loader": "^4.0.0",
-        "vega-util": "^1.11.0"
+        "vega-format": "^1.0.4",
+        "vega-loader": "^4.3.2",
+        "vega-util": "^1.16.1"
       }
     },
     "vega-encode": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.5.2.tgz",
-      "integrity": "sha512-iL1njX++VE0SAMJuDqc0k9kmsU8AeyRRHv15MXh2+PXe2JmyiSWn6HcF3RzFUy5xmKlZOU5BiL8KrTgTrxh+WA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
+      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
       "requires": {
-        "d3-array": "^2.4.0",
-        "d3-format": "^1.4.2",
-        "d3-interpolate": "^1.4.0",
-        "vega-dataflow": "^5.5.0",
-        "vega-scale": "^6.0.0",
-        "vega-time": "^1.0.0",
-        "vega-util": "^1.12.2"
-      },
-      "dependencies": {
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
-        "d3-interpolate": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-          "requires": {
-            "d3-color": "1"
-          }
-        }
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.0.3",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-event-selector": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.2.tgz",
-      "integrity": "sha512-Uv72vBfM0lrlI2belKHFMZuVnW2uJl2ShqWPwGSXPVe6p+PzgqoPJYC8A/i5N8B54UA4UMDzlbBeo3x7q2W9Yg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
+      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ=="
     },
     "vega-expression": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-2.6.3.tgz",
-      "integrity": "sha512-sME1+45BToTGsftb1Q6Ubs2iRYEoXkD2NRGnJuKS9YJ2ITzZwPHF/jy2kHW3iLpuNjj54meaO7HMQ/hUKrciUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
+      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
       "requires": {
-        "vega-util": "^1.11.0"
+        "@types/estree": "^0.0.50",
+        "vega-util": "^1.16.0"
       }
     },
     "vega-force": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.3.tgz",
-      "integrity": "sha512-4stItN4jD9H1CENaCz4jXRNS1Bi9cozMOUjX2824FeJENi2RZSiAZAaGbscgerZQ/jbNcOHD8PHpC2pWldEvGA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
+      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
       "requires": {
-        "d3-force": "^2.0.1",
-        "vega-dataflow": "^5.4.0",
-        "vega-util": "^1.11.0"
+        "d3-force": "^2.1.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
+      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-format": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "vega-time": "^2.0.3",
+        "vega-util": "^1.15.2"
+      },
+      "dependencies": {
+        "d3-format": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+          "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+        },
+        "d3-time-format": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+          "requires": {
+            "d3-time": "1 - 2"
+          }
+        }
       }
     },
     "vega-functions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.5.1.tgz",
-      "integrity": "sha512-VTfEwf/ChSOGc4d4yUIgu2XoScky6NH06WN4vwVGY5PREhsyVPsQ+p2zqgD/N/a00EyWPHeOSHEhsPU28oIMtQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
+      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
       "requires": {
-        "d3-array": "^2.4.0",
-        "d3-color": "^1.4.0",
-        "d3-format": "^1.4.2",
-        "d3-geo": "^1.11.9",
-        "d3-time-format": "^2.2.2",
-        "vega-dataflow": "^5.5.0",
-        "vega-expression": "^2.6.3",
-        "vega-scale": "^6.0.0",
-        "vega-scenegraph": "^4.5.0",
-        "vega-selections": "^5.1.0",
-        "vega-statistics": "^1.7.1",
-        "vega-time": "^1.0.0",
-        "vega-util": "^1.12.1"
-      },
-      "dependencies": {
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        }
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-expression": "^5.0.0",
+        "vega-scale": "^7.1.1",
+        "vega-scenegraph": "^4.9.3",
+        "vega-selections": "^5.3.1",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.0"
       }
     },
     "vega-geo": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.0.tgz",
-      "integrity": "sha512-Rcz4z+TR4qy727pjBWSsbMAn8eM9bDZ5MXKqo5AWuFkoj/8ngv13vafHd1tvEMTA8L5BjAW3/eTqN4tyx9KSQg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.8.tgz",
+      "integrity": "sha512-fsGxV96Q/QRgPqOPtMBZdI+DneIiROKTG3YDZvGn0EdV16OG5LzFhbNgLT5GPzI+kTwgLpAsucBHklexlB4kfg==",
       "requires": {
-        "d3-array": "^2.4.0",
-        "d3-color": "^1.4.0",
-        "d3-geo": "^1.11.9",
-        "vega-canvas": "^1.2.1",
-        "vega-dataflow": "^5.1.1",
-        "vega-projection": "^1.4.0",
-        "vega-statistics": "^1.7.1",
-        "vega-util": "^1.12.1"
-      },
-      "dependencies": {
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        }
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-projection": "^1.4.5",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-hierarchy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.3.tgz",
-      "integrity": "sha512-9wNe+KyKqZW1S4++jCC38HuAhZbqNhfY7gOvwiMLjsp65tMtRETrtvYfHkULClm3UokUIX54etAXREAGW7znbw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
+      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
       "requires": {
-        "d3-hierarchy": "^1.1.8",
-        "vega-dataflow": "^5.4.0",
-        "vega-util": "^1.11.0"
+        "d3-hierarchy": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.1.0.tgz",
+      "integrity": "sha512-LAThIiDEsZxYvbSkvPLJ93eJF+Ts8RXv1IpBh8gmew8XGmaLJvVkzdsMe7WJJwuaVEsK7ZZFyB/Inkp842GW6w==",
+      "requires": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-loader": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.1.3.tgz",
-      "integrity": "sha512-50aetjuct4WqU7LctwnZqF/NCyya9aZ1HDQZ9unFi++62vOQgRfbXLNL/dZavqwnWX3S9i0ltCznLyFMG4ck8g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
+      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
       "requires": {
-        "d3-dsv": "^1.1.1",
-        "d3-time-format": "^2.2.1",
-        "node-fetch": "^2.6.0",
-        "topojson-client": "^3.0.1",
-        "vega-util": "^1.11.0"
+        "d3-dsv": "^2.0.0",
+        "node-fetch": "^2.6.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.0.4",
+        "vega-util": "^1.16.0"
       }
     },
     "vega-parser": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-5.12.0.tgz",
-      "integrity": "sha512-sIQcWp7aqafpfELEJr+gQDsz7TlLYaHkowKhp3O/pcOdIuvqeI3IYpP2+oNpXVGi8ikcq8cJLcCUMi9oP2Xtrw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
+      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
       "requires": {
-        "vega-dataflow": "^5.5.0",
-        "vega-event-selector": "^2.0.2",
-        "vega-expression": "^2.6.3",
-        "vega-functions": "^5.5.0",
-        "vega-scale": "^6.0.0",
-        "vega-util": "^1.12.1"
+        "vega-dataflow": "^5.7.3",
+        "vega-event-selector": "^3.0.0",
+        "vega-functions": "^5.12.1",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.16.0"
       }
     },
     "vega-projection": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.0.tgz",
-      "integrity": "sha512-Prb/E41PqZT5b+46rHv6BZLDsXMe+NFClHxJ9NbwW7mntz8aMGAHiYolVa/M2KuTLbsXVgDAPxk/aA9tbQ0SSg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
+      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
       "requires": {
-        "d3-geo": "^1.11.9",
-        "d3-geo-projection": "^2.7.1"
+        "d3-geo": "^2.0.1",
+        "d3-geo-projection": "^3.0.0"
       }
     },
     "vega-regression": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.4.tgz",
-      "integrity": "sha512-fHWJ0t1VEZOzpfBrI66Wo6RxMnqvJXYnXcIUZlOrZ9RLLbb1I6cdEASZp0cQ8M2oYAqu0YVgC0UEjnLs9mJaxQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
+      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
       "requires": {
-        "d3-array": "^2.4.0",
-        "vega-dataflow": "^5.4.1",
-        "vega-statistics": "^1.7.2",
-        "vega-util": "^1.12.2"
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-runtime": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-5.0.2.tgz",
-      "integrity": "sha512-Cuv+RY6kprH+vtNERg6xP4dgcdYGD2ZnxPxJNEtGi7dmtQQTBa1s7jQ0VDXTolsO6lKJ3B7np2GzKJYwevgj1A==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
+      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
       "requires": {
-        "vega-dataflow": "^5.1.1",
-        "vega-util": "^1.11.0"
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-scale": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-6.0.0.tgz",
-      "integrity": "sha512-uNJ5LC+s+XLxdO2iXC36/TLen3mMNv0wzhMZMNXa8h+Ih10geJ57sHbYYA8Z8403JC9AYTaWUe7m0H9CHgV9NA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
+      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
       "requires": {
-        "d3-array": "^2.4.0",
-        "d3-interpolate": "^1.4.0",
-        "d3-scale": "^3.2.1",
-        "vega-util": "^1.12.1"
-      },
-      "dependencies": {
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
-        "d3-interpolate": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-          "requires": {
-            "d3-color": "1"
-          }
-        }
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.2",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-scenegraph": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.5.0.tgz",
-      "integrity": "sha512-nO1bTFwhLdkOPzJ++f8dmlMX6OLZya9c94/HZNwFRfGNfri1vXyCIudFwCJD9/h0dJ0kSWfG8ybH9wDQMcZZDw==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz",
+      "integrity": "sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==",
       "requires": {
-        "d3-path": "^1.0.9",
-        "d3-shape": "^1.3.7",
-        "vega-canvas": "^1.2.1",
-        "vega-loader": "^4.1.3",
-        "vega-util": "^1.12.1"
+        "d3-path": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "vega-canvas": "^1.2.5",
+        "vega-loader": "^4.3.3",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-selections": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.0.tgz",
-      "integrity": "sha512-vC4NPsuN+IffruFXfH0L3i2A51RgG4PqpLv85TvrEAIYnSkyKDE4bf+wVraR3aPdnLLkc3+tYuMi6le5FmThIA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
+      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
       "requires": {
-        "vega-expression": "^4.0.1",
+        "vega-expression": "^5.0.0",
         "vega-util": "^1.16.0"
-      },
-      "dependencies": {
-        "vega-expression": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
-          "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
-          "requires": {
-            "vega-util": "^1.16.0"
-          }
-        },
-        "vega-util": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
-          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg=="
-        }
       }
     },
     "vega-statistics": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.2.tgz",
-      "integrity": "sha512-G6rvZ50MqnmiN1fGqDnFoCLWFwBCYt3nCucXu3zWov7A1/lsatvbDKYeSlVlnvT9OHtv4L+3pRpepFh5IhXKFg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
+      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
       "requires": {
-        "d3-array": "^2.4.0"
+        "d3-array": "^2.7.1"
       }
     },
     "vega-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-1.0.0.tgz",
-      "integrity": "sha512-r0yOFr/VklJwD3ew1+fEcB7E0LBCLChYlwh0KoO6cTIWMdlC4KhIIUN3/FuBfUZ4qx4V/xp71xH2YYYZTH6izg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
+      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
       "requires": {
-        "d3-array": "^2.3.3",
-        "d3-time": "^1.1.0",
-        "d3-time-format": "^2.2.1",
-        "vega-util": "^1.12.0"
-      }
-    },
-    "vega-transforms": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.6.0.tgz",
-      "integrity": "sha512-5nsMMnyOME/Xe1xLNGCcQ+BS94cix9gSItHiXqU7wR50ukp5U9JoUxnfeYJkuv37FAbnFpkuYlPcBCWp55zXhQ==",
-      "requires": {
-        "d3-array": "^2.4.0",
-        "vega-dataflow": "^5.5.0",
-        "vega-statistics": "^1.7.1",
-        "vega-time": "^1.0.0",
-        "vega-util": "^1.12.1"
-      }
-    },
-    "vega-typings": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.12.0.tgz",
-      "integrity": "sha512-K+IoUTTtXW3E1Qhr/y+JgLRxy476viAm6DeM8IiVrA8vvuLA3FTzHaeI7TCnaWEwk9xxLJBtdVKKC5FGbp0Nyw==",
-      "requires": {
-        "vega-util": "^1.12.1"
-      }
-    },
-    "vega-util": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.12.2.tgz",
-      "integrity": "sha512-p02+oQ/XU/gzY9S/CTZinym2NKWEMIneLc+FYdUeJZZnDGa3DvcNgUDlVR90JlwLcYZNs5dBdfYLfdRHsKZKiw=="
-    },
-    "vega-view": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.4.0.tgz",
-      "integrity": "sha512-Q8nH93NceWJRB4/KTehOvsrpbCGGDnkjOCcNQpTsGgu6QRmgMTHtRQTHkE+LhLXMO/55zZrVR22thvMEH9r36w==",
-      "requires": {
-        "d3-array": "^2.4.0",
-        "d3-timer": "^1.0.10",
-        "vega-dataflow": "^5.5.0",
-        "vega-functions": "^5.5.1",
-        "vega-runtime": "^5.0.2",
-        "vega-scenegraph": "^4.5.0",
-        "vega-util": "^1.12.1"
+        "d3-array": "^2.7.1",
+        "d3-time": "^2.0.0",
+        "vega-util": "^1.15.2"
       },
       "dependencies": {
-        "d3-timer": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        "d3-time": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+          "requires": {
+            "d3-array": "2"
+          }
         }
       }
     },
-    "vega-view-transforms": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.0.tgz",
-      "integrity": "sha512-8n52147HxNSjQ23NeHN//AWt99zZP+Ukiy4kSbkCJGPZ3dW3NYdunEYNvZWyMmOKSrHIMtgdcHUM9FmPTQpE9w==",
+    "vega-transforms": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.4.tgz",
+      "integrity": "sha512-JGBhm5Bf6fiGTUSB5Qr5ckw/KU9FJcSV5xIe/y4IobM/i/KNwI1i1fP45LzP4F4yZc0DMTwJod2UvFHGk9plKA==",
       "requires": {
-        "vega-dataflow": "^5.4.1",
-        "vega-scenegraph": "^4.4.0",
-        "vega-util": "^1.12.0"
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.4",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "vega-typings": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.0.tgz",
+      "integrity": "sha512-TgBGRkZHQgcduGsoFKq3Scpn6eNY4L3p0YKRhgCPVU3HEaCeYkPFGaR8ynK+XrKmvrqpDv0YHIOwCt7Gn3RpCA==",
+      "requires": {
+        "vega-event-selector": "^3.0.0",
+        "vega-expression": "^5.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-util": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
+      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w=="
+    },
+    "vega-view": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.10.1.tgz",
+      "integrity": "sha512-4xvQ5KZcgKdZx1Z7jjenCUumvlyr/j4XcHLRf9gyeFrFvvS596dVpL92V8twhV6O++DmS2+fj+rHagO8Di4nMg==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-timer": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-format": "^1.0.4",
+        "vega-functions": "^5.10.0",
+        "vega-runtime": "^6.1.3",
+        "vega-scenegraph": "^4.9.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
+      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-voronoi": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.1.tgz",
-      "integrity": "sha512-agLmr+UGxJs5KB9D8GeZqxgeWWGoER/eVHPcFFPgVuoNBsrqf2bdoltmIkRnpiRsQnGCibGixhFEDCc9GGNAww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
+      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
       "requires": {
-        "d3-delaunay": "^5.1.3",
-        "vega-dataflow": "^5.1.1",
-        "vega-util": "^1.11.0"
+        "d3-delaunay": "^5.3.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
       }
     },
     "vega-wordcloud": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.0.4.tgz",
-      "integrity": "sha512-+FwgCKTj8JBMbBjNiVciLvjQnk+rC59uyecmlTsmtUGVZz5wyANooYcXt4xtiRu+G8ohdlJ6L/59+UFTaUR8og==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
+      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
       "requires": {
-        "vega-canvas": "^1.2.1",
-        "vega-dataflow": "^5.4.1",
-        "vega-scale": "^6.0.0",
-        "vega-statistics": "^1.7.1",
-        "vega-util": "^1.12.1"
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.1.1",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
       }
     },
     "vendors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,9 +426,9 @@
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
     "@hapi/hapi": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.5.tgz",
-      "integrity": "sha512-BhJ5XFR9uWPUBj/z5pPqXSk8OnvQQU/EbQjwpmjZy0ymNEiq7kIhXkAmzXcntbBHta9o7zpW8XMeXnfV4wudXw==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.1.tgz",
+      "integrity": "sha512-OXAU+yWLwkMfPFic+KITo+XPp6Oxpgc9WUH+pxXWcTIuvWbgco5TC/jS8UDvz+NFF5IzRgF2CL6UV/KLdQYUSQ==",
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -461,14 +461,14 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "@hapi/inert": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.3.tgz",
-      "integrity": "sha512-Z6Pi0Wsn2pJex5CmBaq+Dky9q40LGzXLUIUFrYpDtReuMkmfy9UuUeYc4064jQ1Xe9uuw7kbwE6Fq6rqKAdjAg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.4.tgz",
+      "integrity": "sha512-tpmNqtCCAd+5Ts07bJmMaA79+ZUIf0zSWnQMaWtbcO4nGrO/yXB2AzoslfzFX2JEV9vGeF3FfL8mYw0pHl8VGg==",
       "requires": {
         "@hapi/ammo": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -919,54 +919,48 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "autoprefixer": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
-      "integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
+      "version": "10.3.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.7.tgz",
+      "integrity": "sha512-EmGpu0nnQVmMhX8ROoJ7Mx8mKYPlcUHuxkwrRYEYMz85lu7H09v8w6R1P0JPdn/hKU32GjpLBFEOuIlDWCRWvg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
+        "browserslist": "^4.17.3",
+        "caniuse-lite": "^1.0.30001264",
         "fraction.js": "^4.1.1",
         "normalize-range": "^0.1.2",
+        "picocolors": "^0.2.1",
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.16.8",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-          "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+          "version": "4.17.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+          "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001251",
-            "colorette": "^1.3.0",
-            "electron-to-chromium": "^1.3.811",
+            "caniuse-lite": "^1.0.30001264",
+            "electron-to-chromium": "^1.3.857",
             "escalade": "^3.1.1",
-            "node-releases": "^1.1.75"
+            "node-releases": "^1.1.77",
+            "picocolors": "^0.2.1"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001251",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-          "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
-          "dev": true
-        },
-        "colorette": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+          "version": "1.0.30001265",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+          "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.817",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.817.tgz",
-          "integrity": "sha512-Vw0Faepf2Id9Kf2e97M/c99qf168xg86JLKDxivvlpBQ9KDtjSeX0v+TiuSE25PqeQfTz+NJs375b64ca3XOIQ==",
+          "version": "1.3.867",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.867.tgz",
+          "integrity": "sha512-WbTXOv7hsLhjJyl7jBfDkioaY++iVVZomZ4dU6TMe/SzucV6mUAs2VZn/AehBwuZMiNEQDaPuTGn22YK5o+aDw==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.75",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-          "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+          "version": "1.1.77",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+          "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
           "dev": true
         }
       }
@@ -1500,9 +1494,9 @@
       }
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
+      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
     },
     "debug": {
       "version": "4.3.1",
@@ -2132,9 +2126,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2555,9 +2549,9 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
     },
     "mime-types": {
       "version": "2.1.32",
@@ -2634,9 +2628,9 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+      "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
       "dev": true
     },
     "natural-compare": {
@@ -2652,9 +2646,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-releases": {
       "version": "1.1.73",
@@ -2734,9 +2752,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-path": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
-      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA=="
     },
     "once": {
       "version": "1.4.0",
@@ -2795,6 +2813,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
@@ -2808,13 +2832,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
         "source-map-js": "^0.6.2"
       }
     },
@@ -3233,9 +3257,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.1.tgz",
-      "integrity": "sha512-Lj8nPaSYOuRhgqdyShV50fY5jKnvaRmikUNalMPmbH+tKMGgEKVkltI/lP30PEfO2T1t6R9yc2QIBLgOc3uaFw==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -3344,9 +3368,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
-      "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.1.tgz",
+      "integrity": "sha512-5ofqMTbetNhxlzjYYLBaZFQd6oiTuSkQlyfPEFIMwgUABlZQ0hbk5xIV9Ydd5jghWeRoO7GkiJliUvTpLOjNRA=="
     },
     "source-map": {
       "version": "0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nunjucks": "^3.2.2",
     "object-path": "^0.11.5",
     "slugify": "^1.6.0",
-    "vega": "5.9.1"
+    "vega": "^5.21.0"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-chart",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "@hapi/boom": "^9.1.4",
     "@hapi/bourne": "^2.0.0",
-    "@hapi/hapi": "^20.1.5",
-    "@hapi/hoek": "^9.2.0",
-    "@hapi/inert": "^6.0.3",
+    "@hapi/hapi": "^20.2.1",
+    "@hapi/hoek": "^9.2.1",
+    "@hapi/inert": "^6.0.4",
     "ajv": "^6.12.6",
     "array2d": "0.0.5",
     "canvas": "^2.8.0",
@@ -24,26 +24,26 @@
     "d3-scale": "^3.2.3",
     "d3-time": "^1.1.0",
     "d3-time-format": "^2.3.0",
-    "date-fns": "^2.23.0",
+    "date-fns": "^2.25.0",
     "decimal.js": "^10.3.1",
     "deepmerge": "^4.2.2",
     "joi": "^17.4.2",
     "jsdom": "^16.7.0",
     "moment-timezone": "^0.5.33",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.5",
     "nunjucks": "^3.2.2",
-    "object-path": "^0.11.5",
-    "slugify": "^1.6.0",
+    "object-path": "^0.11.8",
+    "slugify": "^1.6.1",
     "vega": "^5.21.0"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.3",
     "@hapi/lab": "^24.3.2",
-    "autoprefixer": "^10.3.2",
+    "autoprefixer": "^10.3.7",
     "cssnano": "^5.0.8",
-    "glob": "^7.1.7",
-    "postcss": "^8.3.6",
+    "glob": "^7.2.0",
+    "postcss": "^8.3.9",
     "postcss-import": "^14.0.2",
-    "sass": "^1.38.1"
+    "sass": "^1.42.1"
   }
 }


### PR DESCRIPTION
- (postprocessing) Updates postprocessings to use opacity attribute instead of inline style in order to upgrade vega to latest version
- Updates dependencies