### PR TITLE
(column-stacked) Add showOnlyFirstAndLastLabel postprocessing

### DIFF
--- a/chartTypes/column-stacked/postprocessings.js
+++ b/chartTypes/column-stacked/postprocessings.js
@@ -3,5 +3,6 @@ const commonPostprocessings = require("../commonPostprocessings.js");
 module.exports = [
   commonPostprocessings.addPrognosisPattern,
   commonPostprocessings.hideRepeatingTickLabels,
-  commonPostprocessings.highlightZeroGridLineIfPositiveAndNegative
+  commonPostprocessings.highlightZeroGridLineIfPositiveAndNegative,
+  commonPostprocessings.showOnlyFirstAndLastLabel,
 ];


### PR DESCRIPTION
This PR adds `showOnlyFirstAndLastLabel` postprocessing step to `column-stacked` chart type. This was already added to `column` chart type in https://github.com/nzzdev/Q-chart/pull/225, but was forgotten to also add to `column-stacked`.

Before:
![Screenshot 2021-10-14 at 14 17 39](https://user-images.githubusercontent.com/1810384/137315811-b71b8525-66e8-45fb-a06e-37c66cdd6c0e.png)

After:
![Screenshot 2021-10-14 at 14 18 09](https://user-images.githubusercontent.com/1810384/137315828-1987939e-a7b2-4de9-9dc7-2d7ef75600ee.png)

