### PR TITLE
remove line highlight in print

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
         "DIVERGING_COLOR_SCHEMES": "[{ \"label\": \"one\", \"key\": 0, \"scheme_name\": \"diverging_one\" }, { \"label\": \"two\", \"key\": 1, \"scheme_name\": \"diverging_two\" }, { \"label\": \"three\", \"key\": 2, \"scheme_name\": \"diverging_three\" } ]",
         "FONTS": "[{\"url\": \"https://assets.static-nzz.ch/nzz-niobe/assets/fonts/GT-America-Standard-Regular.otf\",\"name\": \"nzz-sans-serif\",\"filename\": \"nzz-sans-serif.otf\"}]"
       },
-      "program": "${workspaceRoot}/index.js"
+      "program": "${workspaceRoot}/index.js",
+      "runtimeVersion": "14.15.3",
     },
     {
       "type": "node",

--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -100,6 +100,10 @@ module.exports = {
       // nevermind and keep the default legendType;
     }
 
+    if (toolRuntimeConfig.removeHighlightDataSeries) {
+      item.options.highlightDataSeries.length = 0;
+    }
+
     const context = {
       item: item,
       events: {


### PR DESCRIPTION
- add new property in toolRuntimeConfig for removing line highlight. This is mainly a print issue, because highlighting certain lines makes the rest appear very light and some people can't see them properly anymore.
- pull request for Q-server-nzz: https://github.com/nzzdev/Q-server-nzz/pull/507
- Test here: https://q.st-staging.nzz.ch/item/ecf1db20c4ca6dcf6e790990670989f7